### PR TITLE
fix(data): Assign persistent IDs to orders via GitHub Action

### DIFF
--- a/test_id_assignment.sh
+++ b/test_id_assignment.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Test Setup ---
+# Create a dummy orders.json file with some existing data
+cat > orders.json << EOL
+[
+  {
+    "id": 1,
+    "klantNaam": "Test Klant 1"
+  },
+  {
+    "id": 3,
+    "klantNaam": "Test Klant 3"
+  }
+]
+EOL
+
+# Create a dummy new_item.json, simulating the output from the 'extract' step
+cat > new_item.json << EOL
+{
+  "klantNaam": "Nieuwe Klant"
+}
+EOL
+
+echo "--- Test Files Created ---"
+echo "orders.json:"
+cat orders.json
+echo ""
+echo "new_item.json:"
+cat new_item.json
+echo ""
+
+# --- Run the Logic from the GitHub Action ---
+echo "--- Running ID Generation Logic ---"
+# 1. Bepaal het volgende ID
+max_id=$(jq '[.[] .id] | max // 0' orders.json)
+next_id=$((max_id + 1))
+
+echo "Max ID found: $max_id"
+echo "Next ID calculated: $next_id"
+
+# 2. Voeg metadata en het nieuwe ID toe
+jq --argjson id "$next_id" \
+   '. + {id:$id}' new_item.json > new_item_with_meta.json
+
+echo ""
+echo "new_item_with_meta.json created:"
+cat new_item_with_meta.json
+echo ""
+
+# 3. Voeg het nieuwe item toe aan de array
+tmp=$(mktemp)
+jq --slurp '.[0] + [.[1]]' orders.json new_item_with_meta.json > "$tmp"
+mv "$tmp" orders.json
+
+echo "--- Verification ---"
+echo "Final orders.json:"
+cat orders.json
+echo ""
+
+# --- Assertions ---
+# Verify the new item has the correct ID
+new_item_id=$(jq '.[] | select(.klantNaam == "Nieuwe Klant") | .id' orders.json)
+
+echo "ID of new item in file: $new_item_id"
+echo "Expected ID: $next_id"
+
+if [ "$new_item_id" -ne "$next_id" ]; then
+    echo "TEST FAILED: New item ID is incorrect!"
+    exit 1
+fi
+
+# Verify the highest ID in the file is now the new ID
+final_max_id=$(jq '[.[] .id] | max' orders.json)
+if [ "$final_max_id" -ne "$next_id" ]; then
+    echo "TEST FAILED: Final max ID is incorrect!"
+    exit 1
+fi
+
+echo "--- Test Passed! ---"
+
+# --- Cleanup ---
+rm orders.json new_item.json new_item_with_meta.json

--- a/v3/.github/workflows/issues-to-json.yml
+++ b/v3/.github/workflows/issues-to-json.yml
@@ -41,12 +41,19 @@ jobs:
 
       - name: Voeg record toe aan data/orders.json
         run: |
+          # Bepaal het volgende ID
+          max_id=$(jq '[.[] .id] | max // 0' data/orders.json)
+          next_id=$((max_id + 1))
+
+          # Voeg metadata en het nieuwe ID toe
           jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
              --arg issue "#${{ github.event.issue.number }}" \
-             '. + {issue:$issue, createdAt:$now}' new_item.json > new_item_with_meta.json
+             --argjson id "$next_id" \
+             '. + {id:$id, issue:$issue, createdAt:$now}' new_item.json > new_item_with_meta.json
 
+          # Voeg het nieuwe item toe aan de array
           tmp=$(mktemp)
-          jq -s '.[0] + [.[1]]' data/orders.json new_item_with_meta.json > "$tmp"
+          jq --slurp '.[0] + [.[1]]' data/orders.json new_item_with_meta.json > "$tmp"
           mv "$tmp" data/orders.json
 
       - name: Commit & push

--- a/v3/assets/js/features/orders.js
+++ b/v3/assets/js/features/orders.js
@@ -197,11 +197,10 @@ export async function loadOrdersFromGitHub(){
     const res = await fetch(GH_RAW_ORDERS_URL, { cache: 'no-store' });
     if(!res.ok) throw new Error('HTTP ' + res.status);
     const arr = await res.json();
-    // arr is expected to be an array of items (objects)
-    // map ids if missing
-    const mapped = (arr || []).map((o, i) => ({ id: o.id || (i+1), ...o }));
-    replaceTransportOrders(mapped);
-    alert(`${mapped.length} orders geladen uit GitHub JSON.`);
+    // ID's worden nu beheerd door de GitHub Action, dus we kunnen de data direct gebruiken.
+    const orders = Array.isArray(arr) ? arr : [];
+    replaceTransportOrders(orders);
+    alert(`${orders.length} orders geladen uit GitHub JSON.`);
     loadOrders();
   } catch (err) {
     alert('Laden uit GitHub mislukt: ' + err.message);


### PR DESCRIPTION
The previous implementation did not assign a persistent, unique ID to new orders created via GitHub Issues. The client-side code would generate temporary, index-based IDs on each data load. This caused IDs to be unstable, leading to incorrect behavior in features like "edit" and "delete" if the underlying data changed.

This commit fixes the bug by moving the ID assignment logic to the `issues-to-json.yml` GitHub Action. The action now calculates the next available ID by finding the maximum existing ID in `data/orders.json` and incrementing it. This ensures every new order receives a permanent and unique ID.

The client-side JavaScript in `orders.js` has been simplified to remove the faulty ID generation logic.

A shell script, `test_id_assignment.sh`, has been added to test and verify that the new ID generation logic in the action is correct.