### PR TITLE
Split user and planner functionality into dedicated modules

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,49 +1,27 @@
-import { users, transports, trucks, locations } from './database.js';
+import { users, transports, trucks } from './database.js';
+import { createUserPortal } from './portals/userPortal.js';
+import { createPlannerPortal } from './portals/plannerPortal.js';
 
 let currentUserId = null;
-let map;
-let deviceCounter = 0;
+let userPortal;
+let plannerPortal;
+let mainTabsInitialized = false;
+let appDelegationAttached = false;
+let headerListenersAttached = false;
+let modalListenersAttached = false;
 
 // --- TEMPLATING & RENDERING ---
 const renderViews = () => {
-    document.getElementById('view-user').innerHTML = `<div class="mb-4 border-b border-gray-200"><nav class="flex -mb-px"><button id="subtab-user-dashboard" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text sub-tab-active">Mijn Transporten</button><button id="subtab-user-new" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text">Nieuwe Aanvraag</button></nav></div><div id="subview-user-dashboard" class="subview-section active"><div class="flex justify-between items-center mb-4"><h2 class="text-xl font-semibold">Overzicht van mijn transporten</h2><button data-action="show-new-request-form" class="motrac-blue text-white font-bold py-2 px-4 rounded-lg flex items-center space-x-2 hover:opacity-90 transition-opacity"><i data-lucide="plus" class="w-5 h-5"></i><span>Nieuwe Aanvraag</span></button></div><div class="bg-white p-4 rounded-lg shadow-sm"><div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-xs text-gray-700 uppercase bg-gray-50"><tr><th scope="col" class="px-6 py-3">Order ID</th><th scope="col" class="px-6 py-3">Van</th><th scope="col" class="px-6 py-3">Naar</th><th scope="col" class="px-6 py-3">Gewenste datum</th><th scope="col" class="px-6 py-3">Status</th><th scope="col" class="px-6 py-3">Acties</th></tr></thead><tbody id="transport-list-body"></tbody></table></div></div></div><div id="subview-user-new" class="subview-section"><h2 class="text-xl font-semibold mb-4">Nieuwe transportaanvraag</h2><form id="transport-form" class="space-y-8 bg-white p-6 rounded-lg shadow-sm"></form></div>`;
-    document.getElementById('view-planner').innerHTML = `<h2 class="text-xl font-semibold mb-4">Planner Dashboard</h2><div class="grid grid-cols-1 lg:grid-cols-5 gap-6"><div class="lg:col-span-2 space-y-6"><div class="bg-white p-4 rounded-lg shadow-sm"><h3 class="font-semibold mb-3 border-b pb-2">Nieuwe Aanvragen</h3><div id="new-requests-list" class="space-y-3 h-[30vh] overflow-y-auto p-1"></div></div><div class="bg-white p-4 rounded-lg shadow-sm"><h3 class="font-semibold mb-3 border-b pb-2">Vrachtwagens voor vandaag</h3><div class="space-y-4" id="trucks-container"></div></div></div><div class="lg:col-span-3"><div id="map"></div></div></div>`;
+    userPortal.renderView(document.getElementById('view-user'));
+    plannerPortal.renderView(document.getElementById('view-planner'));
+    renderAdminView();
+};
+
+const renderAdminView = () => {
     document.getElementById('view-admin').innerHTML = `<div class="mb-4 border-b border-gray-200"><nav class="flex -mb-px"><button id="subtab-admin-users" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text sub-tab-active">Gebruikersbeheer</button><button id="subtab-admin-trucks" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text">Vrachtwagenbeheer</button></nav></div><div id="subview-admin-users" class="subview-section active"><div class="flex justify-between items-center mb-4"><h2 class="text-xl font-semibold">Gebruikersoverzicht</h2><button data-action="open-modal" data-modal-id="user-modal" class="motrac-blue text-white font-bold py-2 px-4 rounded-lg flex items-center space-x-2 hover:opacity-90 transition-opacity"><i data-lucide="user-plus" class="w-5 h-5"></i><span>Nieuwe Gebruiker</span></button></div><div class="bg-white p-4 rounded-lg shadow-sm"><div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-xs text-gray-700 uppercase bg-gray-50"><tr><th scope="col" class="px-6 py-3">Naam</th><th scope="col" class="px-6 py-3">Email</th><th scope="col" class="px-6 py-3">Rol</th><th scope="col" class="px-6 py-3">Status</th><th scope="col" class="px-6 py-3">Acties</th></tr></thead><tbody id="user-list-body"></tbody></table></div></div></div><div id="subview-admin-trucks" class="subview-section"><div class="flex justify-between items-center mb-4"><h2 class="text-xl font-semibold">Vrachtwagenoverzicht</h2><button data-action="open-modal" data-modal-id="truck-modal" class="motrac-blue text-white font-bold py-2 px-4 rounded-lg flex items-center space-x-2 hover:opacity-90 transition-opacity"><i data-lucide="truck" class="w-5 h-5"></i><span>Nieuwe Vrachtwagen</span></button></div><div class="bg-white p-4 rounded-lg shadow-sm"><div class="overflow-x-auto"><table class="w-full text-sm text-left"><thead class="text-xs text-gray-700 uppercase bg-gray-50"><tr><th scope="col" class="px-6 py-3">ID</th><th scope="col" class="px-6 py-3">Chauffeur</th><th scope="col" class="px-6 py-3">Capaciteit (objecten)</th><th scope="col" class="px-6 py-3">Acties</th></tr></thead><tbody id="truck-list-body"></tbody></table></div></div></div>`;
-};
-
-const renderTransportForm = () => {
-     const form = document.getElementById('transport-form');
-     if (!form) return;
-     form.innerHTML = `
-        <div><h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">1. Locatiegegevens</h3><div class="grid grid-cols-1 md:grid-cols-2 gap-6"><div><label for="from" class="block text-sm font-medium text-gray-700 mb-1">Van</label><input type="text" name="from" class="w-full p-2 border rounded-md" value="Rondebeltweg 51, Almere" required></div><div><label for="to" class="block text-sm font-medium text-gray-700 mb-1">Naar</label><input type="text" name="to" class="w-full p-2 border rounded-md" placeholder="Adres van klant" required></div></div></div>
-        <div><h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">2. Te Vervoeren Objecten</h3><div id="devices-container" class="space-y-4"></div><div class="mt-4"><button type="button" id="add-device-btn" class="text-sm motrac-blue-text font-semibold hover:underline flex items-center gap-1"><i data-lucide="plus-circle" class="w-4 h-4"></i>Extra machine toevoegen</button></div></div>
-        <div><h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">3. Planning en Details</h3>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div><label for="date" class="block text-sm font-medium">Gewenste datum</label><input type="date" name="date" class="w-full p-2 border rounded-md" required></div>
-                <div class="space-y-2">
-                    <label class="block text-sm font-medium">Bijzonderheden</label>
-                    <div class="flex items-center"><input type="checkbox" id="first-job" name="first-job" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"><label for="first-job" class="ml-2 block text-sm text-gray-900">Eerste werk?</label></div>
-                    <div class="flex items-center"><input type="checkbox" id="loading-dock" name="loading-dock" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"><label for="loading-dock" class="ml-2 block text-sm text-gray-900">Laaddock aanwezig?</label></div>
-                </div>
-            </div>
-        </div>
-        <div class="flex justify-end space-x-4 pt-6 border-t"><button type="button" id="cancel-transport-btn" class="bg-gray-200 px-6 py-2 rounded-lg">Annuleren</button><button type="submit" class="motrac-blue text-white px-6 py-2 rounded-lg">Aanvraag Indienen</button></div>`;
-     addDeviceRow(true);
-     lucide.createIcons();
-};
-
-const renderTransportList = () => {
-    const listBody = document.getElementById('transport-list-body');
-    if(!listBody) return;
-    listBody.innerHTML = '';
-    const statusStyles = { 'Ingepland': 'bg-blue-100 text-blue-800', 'Uitgevoerd': 'bg-green-100 text-green-800', 'Aangevraagd': 'bg-yellow-100 text-yellow-800', 'Geannuleerd': 'bg-red-100 text-red-800' };
-    transports.forEach(t => {
-        listBody.innerHTML += `<tr class="bg-white border-b">
-            <td class="px-6 py-4 font-medium">${t.id}</td><td class="px-6 py-4">${t.from}</td><td class="px-6 py-4">${t.to}</td><td class="px-6 py-4">${t.date}</td>
-            <td class="px-6 py-4"><span class="${statusStyles[t.status] || ''} text-xs font-medium mr-2 px-2.5 py-0.5 rounded-full">${t.status}</span></td>
-            <td class="px-6 py-4 flex space-x-2"><button data-action="open-transport-details" data-transport-id="${t.id}" class="p-1 text-gray-500 hover:text-blue-600"><i data-lucide="eye"></i></button><button class="p-1 text-gray-500 hover:text-blue-600"><i data-lucide="pencil"></i></button></td></tr>`;
-    });
-    lucide.createIcons();
+    if (typeof lucide !== 'undefined' && typeof lucide.createIcons === 'function') {
+        lucide.createIcons();
+    }
 };
 
 const renderUserList = () => {
@@ -77,37 +55,6 @@ const renderTruckList = () => {
                 <button data-action="delete-truck" data-truck-id="${t.id}" class="p-1 text-gray-500 hover:text-red-600" title="Verwijderen"><i data-lucide="trash-2" class="w-4 h-4"></i></button>
             </td></tr>`;
     });
-    lucide.createIcons();
-};
-
-const renderPlanner = () => {
-    const requestsList = document.getElementById('new-requests-list');
-    const trucksContainer = document.getElementById('trucks-container');
-    if (!requestsList || !trucksContainer) return;
-    requestsList.innerHTML = '';
-    trucksContainer.innerHTML = '';
-
-    trucks.forEach(truck => {
-        trucksContainer.innerHTML += `
-        <div id="${truck.id}" class="truck-bin bg-gray-50 p-3 rounded-lg border-2 border-dashed border-gray-300">
-            <div class="flex justify-between items-center mb-2">
-                <h4 class="font-semibold flex items-center gap-2"><i data-lucide="truck"></i>Vrachtwagen (${truck.driver})</h4>
-                <div class="flex items-center gap-2">
-                    <span class="text-xs font-mono bg-gray-200 px-2 py-1 rounded">0 / ${truck.capacity}</span>
-                    <button data-action="print-truck-list" data-truck-id="${truck.id}" class="p-1 text-gray-500 hover:text-blue-600" title="Rittenlijst printen"><i data-lucide="printer" class="w-4 h-4"></i></button>
-                </div>
-            </div>
-            <div class="drop-zone min-h-[15vh] space-y-2"></div>
-        </div>`;
-    });
-
-    transports.forEach(t => {
-        const requestHtml = `<div id="${t.id}" draggable="true" data-action="open-transport-details" data-transport-id="${t.id}" data-destination="${t.to}" data-device-count="${t.devices.length}" class="p-3 bg-gray-100 rounded-lg shadow-sm cursor-grab border hover:border-blue-500 transition-colors"><p class="font-semibold">${t.id}<span class="text-xs font-normal text-gray-500 ml-2">naar ${t.to}</span></p><p class="text-sm">${t.devices.length} object(en)</p></div>`;
-        const targetContainer = t.plannedOn ? document.querySelector(`#${t.plannedOn} .drop-zone`) : (t.status === 'Aangevraagd' ? requestsList : null);
-        if (targetContainer) targetContainer.innerHTML += requestHtml;
-    });
-    initDragAndDrop();
-    document.querySelectorAll('.truck-bin').forEach(truck => updateTruckLoad(truck.id));
     lucide.createIcons();
 };
 
@@ -149,16 +96,21 @@ const handleLogout = () => {
     document.getElementById('login-container').classList.remove('hidden');
     document.getElementById('login-form').reset();
     document.getElementById('login-error').textContent = '';
-    if(map) { map.remove(); map = null; }
+    plannerPortal.reset();
 };
 
 // --- UI & NOTIFICATIONS ---
-const showNotification = (message, type = 'success') => {
+function showNotification(message, type = 'success') {
     const el = document.getElementById('notification');
     el.textContent = message;
     el.className = `notification no-print ${type} show`;
     setTimeout(() => { el.classList.remove('show'); }, 3000);
-};
+}
+
+userPortal = createUserPortal({ showNotification, lucide });
+plannerPortal = createPlannerPortal({ showNotification, lucide });
+userPortal.setOnTransportCreated(() => plannerPortal.renderPlanner());
+plannerPortal.setRefreshUserList(() => userPortal.renderTransportList());
 
 const openModal = (modalId, itemId = null) => {
     const modal = document.getElementById(modalId);
@@ -269,7 +221,7 @@ document.getElementById('truck-form').addEventListener('submit', (e) => {
     }
     closeModal('truck-modal');
     renderTruckList();
-    renderPlanner();
+    plannerPortal.renderPlanner();
 });
 
 const toggleUserStatus = (userId) => {
@@ -283,7 +235,10 @@ const toggleUserStatus = (userId) => {
 
 const deleteTruck = (truckId) => {
     if (confirm('Weet je zeker dat je deze vrachtwagen wilt verwijderen?')) {
-        trucks = trucks.filter(t => t.id !== truckId);
+        const index = trucks.findIndex(t => t.id === truckId);
+        if (index !== -1) {
+            trucks.splice(index, 1);
+        }
         transports.forEach(t => {
             if (t.plannedOn === truckId) {
                 t.plannedOn = null;
@@ -292,200 +247,10 @@ const deleteTruck = (truckId) => {
         });
         showNotification('Vrachtwagen verwijderd');
         renderTruckList();
-        renderPlanner();
+        plannerPortal.removeTruck(truckId);
+        plannerPortal.renderPlanner();
     }
 };
-
-// --- TRANSPORT FORM FUNCTIONS ---
-const addDeviceRow = (isFirst = false) => {
-    const container = document.getElementById('devices-container');
-    if (!container) return;
-    const newDeviceHTML = `
-        <div class="device-row p-4 border rounded-lg bg-gray-50 relative">
-            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-                <div><label class="text-sm font-medium">Serienummer</label><input type="text" name="sn" placeholder="bv. SN12345" class="mt-1 w-full p-2 border rounded-md"></div>
-                <div><label class="text-sm font-medium">Type</label><input type="text" name="type" placeholder="bv. Heftruck" class="mt-1 w-full p-2 border rounded-md"></div>
-                <div><label class="text-sm font-medium">Hoogte (cm)</label><input type="number" name="height" placeholder="220" class="mt-1 w-full p-2 border rounded-md" min="0"></div>
-                <div><label class="text-sm font-medium">Opmerkingen</label><input type="text" name="notes" placeholder="bv. Stickers plakken" class="mt-1 w-full p-2 border rounded-md"></div>
-            </div>
-            ${!isFirst ? `<button type="button" class="remove-device-btn absolute top-2 right-2 text-gray-400 hover:text-red-600"><i data-lucide="x-circle" class="w-5 h-5"></i></button>` : ''}
-        </div>`;
-    container.insertAdjacentHTML('beforeend', newDeviceHTML);
-    if (!isFirst) lucide.createIcons();
-};
-
-const handleTransportSubmit = (e) => {
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    const from = formData.get('from');
-    const to = formData.get('to');
-    const date = formData.get('date');
-
-    const devices = [];
-    let hasInvalidHeight = false;
-    document.querySelectorAll('.device-row').forEach(row => {
-        const sn = row.querySelector('input[name="sn"]').value;
-        const type = row.querySelector('input[name="type"]').value;
-        const height = row.querySelector('input[name="height"]').value;
-        const notes = row.querySelector('input[name="notes"]').value;
-
-        if (parseFloat(height) < 0) {
-            showNotification('De hoogte van een object kan niet negatief zijn.', 'error');
-            hasInvalidHeight = true;
-            return;
-        }
-
-        if (sn || type) { // only add if there is some data
-            devices.push({ sn, type, height, notes });
-        }
-    });
-
-    if (hasInvalidHeight) return;
-
-    if (!from || !to || !date || devices.length === 0) {
-        showNotification('Vul alle locatie/datum velden en tenminste één object in.', 'error');
-        return;
-    }
-    const newId = 'TR-' + (Math.floor(Math.random() * 9000) + 1000);
-    transports.push({
-        id: newId, from, to, date, status: 'Aangevraagd', plannedOn: null,
-        devices: devices,
-        details: {
-            firstJob: document.getElementById('first-job').checked,
-            loadingDock: document.getElementById('loading-dock').checked
-        }
-    });
-    showNotification(`Transport ${newId} succesvol aangevraagd!`);
-    e.target.reset();
-    document.getElementById('devices-container').innerHTML = '';
-    addDeviceRow(true);
-    renderTransportList();
-    renderPlanner();
-    document.getElementById('subtab-user-dashboard').click();
-};
-
-// --- PLANNER FUNCTIONS ---
-const updateTruckLoad = (truckId) => {
-    const truckBin = document.getElementById(truckId);
-    if (!truckBin) return;
-    const truck = trucks.find(t => t.id === truckId);
-    const loadSpan = truckBin.querySelector('.font-mono');
-    const currentLoad = Array.from(truckBin.querySelectorAll('[data-device-count]')).reduce((sum, el) => sum + parseInt(el.dataset.deviceCount, 10), 0);
-    loadSpan.textContent = `${currentLoad} / ${truck.capacity}`;
-};
-
-const printTruckList = (truckId) => {
-    const truck = trucks.find(t => t.id === truckId);
-    const plannedTransports = transports.filter(t => t.plannedOn === truckId);
-    const printableArea = document.getElementById('printable-area');
-
-    if (!truck || plannedTransports.length === 0) {
-        showNotification('Geen ritten gepland voor deze vrachtwagen.', 'error');
-        return;
-    }
-
-    let printContent = `
-        <div class="p-8 font-sans">
-            <div class="flex justify-between items-center mb-6 border-b pb-4">
-                <h1 class="text-3xl font-bold">Rittenlijst: ${truck.driver}</h1>
-                <p class="text-lg">Datum: ${new Date().toLocaleDateString('nl-NL')}</p>
-            </div>
-    `;
-
-    plannedTransports.forEach((transport, index) => {
-        printContent += `
-            <div class="mb-6 p-4 border rounded-lg" style="page-break-inside: avoid;">
-                <h2 class="text-xl font-semibold mb-3 bg-gray-100 p-2 rounded">Stop ${index + 1}: ${transport.to} (Order: ${transport.id})</h2>
-                <div class="grid grid-cols-2 gap-x-4 mb-4">
-                    <p><strong>Van:</strong> ${transport.from}</p>
-                    <p><strong>Naar:</strong> ${transport.to}</p>
-                </div>
-                <h3 class="font-semibold text-gray-800 mt-4 mb-2 border-b pb-1">Bijzonderheden</h3>
-                <p><strong>Eerste werk:</strong> ${transport.details.firstJob ? 'Ja' : 'Nee'}</p>
-                <p><strong>Laaddock aanwezig:</strong> ${transport.details.loadingDock ? 'Ja' : 'Nee'}</p>
-                <h3 class="font-semibold text-gray-800 mt-4 mb-2 border-b pb-1">Objecten (${transport.devices.length})</h3>
-        `;
-        transport.devices.forEach(d => {
-            printContent += `
-                <div class="text-sm mb-2 p-2 bg-gray-50 rounded">
-                    <p><strong>SN:</strong> ${d.sn || '-'} | <strong>Type:</strong> ${d.type || '-'} | <strong>Hoogte:</strong> ${d.height || '-'} cm</p>
-                    <p><strong>Opmerkingen:</strong> ${d.notes || 'Geen'}</p>
-                </div>
-            `;
-        });
-        printContent += `</div>`; // Close transport div
-    });
-
-    printContent += `</div>`; // Close main div
-    printableArea.innerHTML = printContent;
-    window.print();
-};
-
-
-// --- MAP & DRAG-DROP ---
-const truckColors = ['#0033a1', '#22c55e', '#ef4444', '#f97316', '#8b5cf6'];
-let truckRouteLayers = {};
-function initMap() {
-    if(map) return;
-    map = L.map('map').setView([52.2, 5.5], 8);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '© OpenStreetMap' }).addTo(map);
-    trucks.forEach(truck => { truckRouteLayers[truck.id] = L.layerGroup().addTo(map); });
-    updateAllTruckRoutes();
-}
-function updateAllTruckRoutes() {
-    if (!map) return;
-    trucks.forEach(truck => updateTruckRoute(truck.id));
-}
-function updateTruckRoute(truckId, index) {
-    if (!truckRouteLayers[truckId]) {
-        truckRouteLayers[truckId] = L.layerGroup().addTo(map);
-    }
-    truckRouteLayers[truckId].clearLayers();
-    const dropZone = document.querySelector(`#${truckId} .drop-zone`);
-    if (!dropZone) return;
-    let waypoints = [locations['Almere']];
-    dropZone.querySelectorAll('[data-destination]').forEach(req => {
-        const dest = req.dataset.destination;
-        if (locations[dest]) {
-            waypoints.push(locations[dest]);
-            L.marker(locations[dest]).addTo(truckRouteLayers[truckId]).bindPopup(`${req.id} naar ${dest}`);
-        }
-    });
-    if (waypoints.length > 1) {
-        const color = truckColors[trucks.findIndex(t => t.id === truckId) % truckColors.length];
-        L.polyline(waypoints, { color: color || '#333', weight: 5 }).addTo(truckRouteLayers[truckId]);
-    }
-}
-function initDragAndDrop() {
-    document.querySelectorAll('[draggable="true"]').forEach(draggable => {
-        draggable.addEventListener('dragstart', e => { e.target.classList.add('dragging'); e.dataTransfer.setData('text/plain', e.target.id); });
-        draggable.addEventListener('dragend', e => e.target.classList.remove('dragging'));
-    });
-    document.querySelectorAll('.drop-zone, #new-requests-list').forEach(container => {
-        container.addEventListener('dragover', e => { e.preventDefault(); container.closest('.truck-bin, .bg-white')?.classList.add('bg-blue-100'); });
-        container.addEventListener('dragleave', e => { container.closest('.truck-bin, .bg-white')?.classList.remove('bg-blue-100'); });
-        container.addEventListener('drop', e => {
-            e.preventDefault();
-            container.closest('.truck-bin, .bg-white')?.classList.remove('bg-blue-100');
-            const transportId = e.dataTransfer.getData('text/plain');
-            const draggedElement = document.getElementById(transportId);
-            if (draggedElement && !e.currentTarget.contains(draggedElement)) {
-                const oldTruckId = draggedElement.closest('.truck-bin')?.id;
-                e.currentTarget.appendChild(draggedElement);
-                const newTruckId = e.currentTarget.closest('.truck-bin')?.id;
-                const transport = transports.find(t => t.id === transportId);
-                if(transport) {
-                     transport.plannedOn = newTruckId || null;
-                     transport.status = newTruckId ? 'Ingepland' : 'Aangevraagd';
-                }
-                if (oldTruckId) updateTruckLoad(oldTruckId);
-                if (newTruckId) updateTruckLoad(newTruckId);
-                updateAllTruckRoutes();
-                renderTransportList();
-            }
-        });
-    });
-}
 
 // --- APP INITIALIZATION ---
 const initializeApp = () => {
@@ -497,8 +262,34 @@ const initializeApp = () => {
     document.getElementById('tab-admin').style.display = currentUser.role === 'Admin' ? 'block' : 'none';
 
     renderViews();
-    document.getElementById('subtab-user-new').addEventListener('click', renderTransportForm);
+    userPortal.attachListeners();
+
+    const userDashboardTab = document.getElementById('subtab-user-dashboard');
+    if (userDashboardTab) {
+        userDashboardTab.addEventListener('click', () => userPortal.renderTransportList());
+    }
+
+    const userNewTab = document.getElementById('subtab-user-new');
+    if (userNewTab) {
+        userNewTab.addEventListener('click', () => userPortal.renderTransportForm());
+    }
+
+    const adminUsersTab = document.getElementById('subtab-admin-users');
+    if (adminUsersTab) {
+        adminUsersTab.addEventListener('click', renderUserList);
+    }
+
+    const adminTrucksTab = document.getElementById('subtab-admin-trucks');
+    if (adminTrucksTab) {
+        adminTrucksTab.addEventListener('click', renderTruckList);
+    }
+
+    userPortal.renderTransportList();
+    userPortal.renderTransportForm();
+    plannerPortal.renderPlanner();
+
     attachAppListeners();
+
     const firstVisibleTab = document.querySelector('#app .main-tab[style*="display: block"]');
     if (firstVisibleTab) {
         firstVisibleTab.click();
@@ -506,101 +297,99 @@ const initializeApp = () => {
 };
 
 const attachAppListeners = () => {
-    // Main tabs
-    document.querySelectorAll('.main-tab').forEach(tab => {
-        tab.addEventListener('click', (e) => {
-            document.querySelectorAll('.main-tab').forEach(t => t.classList.remove('main-tab-active'));
-            e.currentTarget.classList.add('main-tab-active');
-            const viewId = 'view-' + e.currentTarget.id.split('-')[1];
-            document.querySelectorAll('.view-section').forEach(v => v.classList.toggle('active', v.id === viewId));
-            if (viewId === 'view-planner') {
-                renderPlanner();
-                if (!map) initMap();
-                else setTimeout(() => { map.invalidateSize(); updateAllTruckRoutes(); }, 1);
+    if (!mainTabsInitialized) {
+        document.querySelectorAll('.main-tab').forEach(tab => {
+            tab.addEventListener('click', (e) => {
+                document.querySelectorAll('.main-tab').forEach(t => t.classList.remove('main-tab-active'));
+                e.currentTarget.classList.add('main-tab-active');
+                const viewId = 'view-' + e.currentTarget.id.split('-')[1];
+                document.querySelectorAll('.view-section').forEach(v => v.classList.toggle('active', v.id === viewId));
+
+                if (viewId === 'view-planner') {
+                    plannerPortal.renderPlanner();
+                    plannerPortal.ensureMap();
+                } else if (viewId === 'view-user') {
+                    const dashboardTab = document.getElementById('subtab-user-dashboard');
+                    if (dashboardTab) {
+                        dashboardTab.click();
+                    }
+                } else if (viewId === 'view-admin') {
+                    renderUserList();
+                    renderTruckList();
+                    const adminUsersTab = document.getElementById('subtab-admin-users');
+                    if (adminUsersTab) {
+                        adminUsersTab.click();
+                    }
+                }
+            });
+        });
+        mainTabsInitialized = true;
+    }
+
+    if (!appDelegationAttached) {
+        document.getElementById('app').addEventListener('click', (e) => {
+            const target = e.target.closest('[data-action]');
+            const subTabTarget = e.target.closest('.sub-tab');
+
+            if (subTabTarget) {
+                const parentView = subTabTarget.closest('.view-section');
+                parentView.querySelectorAll('.sub-tab').forEach(t => t.classList.remove('sub-tab-active'));
+                subTabTarget.classList.add('sub-tab-active');
+                const subviewId = 'subview-' + subTabTarget.id.substring(subTabTarget.id.indexOf('-') + 1);
+                parentView.querySelectorAll('.subview-section').forEach(sv => sv.classList.toggle('active', sv.id === subviewId));
             }
-            if (viewId === 'view-user') {
-                renderTransportList();
-                document.getElementById('subtab-user-dashboard').click();
-            }
-             if (viewId === 'view-admin') {
-                renderUserList();
-                renderTruckList();
-                document.getElementById('subtab-admin-users').click();
+
+            if (!target) return;
+
+            const action = target.dataset.action;
+
+            switch (action) {
+                case 'show-new-request-form':
+                    document.getElementById('subtab-user-new').click();
+                    break;
+                case 'open-modal':
+                    openModal(target.dataset.modalId, target.dataset.itemId);
+                    break;
+                case 'open-transport-details':
+                    openModal('transport-details-modal', target.dataset.transportId);
+                    break;
+                case 'toggle-user-status':
+                    toggleUserStatus(target.dataset.userId);
+                    break;
+                case 'delete-truck':
+                    deleteTruck(target.dataset.truckId);
+                    break;
+                case 'print-truck-list':
+                    plannerPortal.printTruckList(target.dataset.truckId);
+                    break;
             }
         });
-    });
+        appDelegationAttached = true;
+    }
 
-    // Centralized event listener using delegation
-    document.getElementById('app').addEventListener('click', (e) => {
-        const target = e.target.closest('[data-action]');
-        const subTabTarget = e.target.closest('.sub-tab');
+    if (!headerListenersAttached) {
+        const bellButton = document.getElementById('bell-button');
+        const userButton = document.getElementById('user-button');
+        const bellDropdown = document.getElementById('bell-dropdown');
+        const userDropdown = document.getElementById('user-dropdown');
+        bellButton.addEventListener('click', (e) => { e.stopPropagation(); userDropdown.classList.add('hidden'); bellDropdown.classList.toggle('hidden'); });
+        userButton.addEventListener('click', (e) => { e.stopPropagation(); bellDropdown.classList.add('hidden'); userDropdown.classList.toggle('hidden'); });
+        window.addEventListener('click', () => { bellDropdown.classList.add('hidden'); userDropdown.classList.add('hidden'); });
+        headerListenersAttached = true;
+    }
 
-        if (subTabTarget) {
-            const parentView = subTabTarget.closest('.view-section');
-            parentView.querySelectorAll('.sub-tab').forEach(t => t.classList.remove('sub-tab-active'));
-            subTabTarget.classList.add('sub-tab-active');
-            const subviewId = 'subview-' + subTabTarget.id.substring(subTabTarget.id.indexOf('-') + 1);
-            parentView.querySelectorAll('.subview-section').forEach(sv => sv.classList.toggle('active', sv.id === subviewId));
-        }
-
-        if (!target) return;
-
-        const action = target.dataset.action;
-
-        switch (action) {
-            case 'show-new-request-form':
-                document.getElementById('subtab-user-new').click();
-                break;
-            case 'open-modal':
-                openModal(target.dataset.modalId, target.dataset.itemId);
-                break;
-            case 'open-transport-details':
-                openModal('transport-details-modal', target.dataset.transportId);
-                break;
-            case 'toggle-user-status':
-                toggleUserStatus(target.dataset.userId);
-                break;
-            case 'delete-truck':
-                deleteTruck(target.dataset.truckId);
-                break;
-            case 'print-truck-list':
-                printTruckList(target.dataset.truckId);
-                break;
-        }
-    });
-
-    // Transport form listeners (using event delegation on the parent)
-    const userView = document.getElementById('view-user');
-    userView.addEventListener('submit', e => {
-        if (e.target.id === 'transport-form') handleTransportSubmit(e);
-    });
-    userView.addEventListener('click', e => {
-         if (e.target.closest('#add-device-btn')) addDeviceRow();
-         if (e.target.id === 'cancel-transport-btn') document.getElementById('subtab-user-dashboard').click();
-         if (e.target.closest('.remove-device-btn')) e.target.closest('.device-row').remove();
-    });
-
-    // Header dropdowns
-    const bellButton = document.getElementById('bell-button');
-    const userButton = document.getElementById('user-button');
-    const bellDropdown = document.getElementById('bell-dropdown');
-    const userDropdown = document.getElementById('user-dropdown');
-    bellButton.addEventListener('click', (e) => { e.stopPropagation(); userDropdown.classList.add('hidden'); bellDropdown.classList.toggle('hidden'); });
-    userButton.addEventListener('click', (e) => { e.stopPropagation(); bellDropdown.classList.add('hidden'); userDropdown.classList.toggle('hidden'); });
-    window.addEventListener('click', () => { bellDropdown.classList.add('hidden'); userDropdown.classList.add('hidden'); });
-
-    // Modal close buttons
-    document.body.addEventListener('click', (e) => {
-        const target = e.target.closest('[data-action="close-modal"]');
-        if (target) {
-            const modal = target.closest('.fixed.inset-0');
-            if (modal) {
-                closeModal(modal.id);
+    if (!modalListenersAttached) {
+        document.body.addEventListener('click', (e) => {
+            const target = e.target.closest('[data-action="close-modal"]');
+            if (target) {
+                const modal = target.closest('.fixed.inset-0');
+                if (modal) {
+                    closeModal(modal.id);
+                }
             }
-        }
-    });
-
-    lucide.createIcons();
+        });
+        modalListenersAttached = true;
+    }
 };
 
 // --- GLOBAL START ---
@@ -611,8 +400,8 @@ document.getElementById('logout-button').addEventListener('click', handleLogout)
 // Expose functions for testing when QUnit is running
 if (typeof QUnit !== 'undefined') {
     window.testable = {
-        handleTransportSubmit,
-        renderTransportForm,
+        handleTransportSubmit: userPortal.handleTransportSubmit,
+        renderTransportForm: userPortal.renderTransportForm,
         showNotification
     };
 }

--- a/src/js/portals/plannerPortal.js
+++ b/src/js/portals/plannerPortal.js
@@ -1,0 +1,286 @@
+import { transports, trucks, locations } from '../database.js';
+
+const truckColors = ['#0033a1', '#22c55e', '#ef4444', '#f97316', '#8b5cf6'];
+const noop = () => {};
+
+export const createPlannerPortal = ({ showNotification, lucide }) => {
+    const state = {
+        refreshUserList: noop
+    };
+
+    let map = null;
+    const truckRouteLayers = {};
+
+    const createIcons = () => {
+        if (lucide && typeof lucide.createIcons === 'function') {
+            lucide.createIcons();
+        }
+    };
+
+    const renderView = (container) => {
+        if (!container) return;
+        container.innerHTML = `
+            <h2 class="text-xl font-semibold mb-4">Planner Dashboard</h2>
+            <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
+                <div class="lg:col-span-2 space-y-6">
+                    <div class="bg-white p-4 rounded-lg shadow-sm">
+                        <h3 class="font-semibold mb-3 border-b pb-2">Nieuwe Aanvragen</h3>
+                        <div id="new-requests-list" class="space-y-3 h-[30vh] overflow-y-auto p-1"></div>
+                    </div>
+                    <div class="bg-white p-4 rounded-lg shadow-sm">
+                        <h3 class="font-semibold mb-3 border-b pb-2">Vrachtwagens voor vandaag</h3>
+                        <div class="space-y-4" id="trucks-container"></div>
+                    </div>
+                </div>
+                <div class="lg:col-span-3">
+                    <div id="map"></div>
+                </div>
+            </div>
+        `;
+        createIcons();
+    };
+
+    const updateTruckLoad = (truckId) => {
+        const truckBin = document.getElementById(truckId);
+        if (!truckBin) return;
+        const truck = trucks.find(t => t.id === truckId);
+        if (!truck) return;
+        const loadSpan = truckBin.querySelector('.font-mono');
+        const currentLoad = Array.from(truckBin.querySelectorAll('[data-device-count]')).reduce((sum, el) => sum + parseInt(el.dataset.deviceCount, 10), 0);
+        if (loadSpan) {
+            loadSpan.textContent = `${currentLoad} / ${truck.capacity}`;
+        }
+    };
+
+    const printTruckList = (truckId) => {
+        const truck = trucks.find(t => t.id === truckId);
+        const plannedTransports = transports.filter(t => t.plannedOn === truckId);
+        const printableArea = document.getElementById('printable-area');
+
+        if (!truck || plannedTransports.length === 0) {
+            showNotification('Geen ritten gepland voor deze vrachtwagen.', 'error');
+            return;
+        }
+
+        let printContent = `
+            <div class="p-8 font-sans">
+                <div class="flex justify-between items-center mb-6 border-b pb-4">
+                    <h1 class="text-3xl font-bold">Rittenlijst: ${truck.driver}</h1>
+                    <p class="text-lg">Datum: ${new Date().toLocaleDateString('nl-NL')}</p>
+                </div>
+        `;
+
+        plannedTransports.forEach((transport, index) => {
+            printContent += `
+                <div class="mb-6 p-4 border rounded-lg" style="page-break-inside: avoid;">
+                    <h2 class="text-xl font-semibold mb-3 bg-gray-100 p-2 rounded">Stop ${index + 1}: ${transport.to} (Order: ${transport.id})</h2>
+                    <div class="grid grid-cols-2 gap-x-4 mb-4">
+                        <p><strong>Van:</strong> ${transport.from}</p>
+                        <p><strong>Naar:</strong> ${transport.to}</p>
+                    </div>
+                    <h3 class="font-semibold text-gray-800 mt-4 mb-2 border-b pb-1">Bijzonderheden</h3>
+                    <p><strong>Eerste werk:</strong> ${transport.details.firstJob ? 'Ja' : 'Nee'}</p>
+                    <p><strong>Laaddock aanwezig:</strong> ${transport.details.loadingDock ? 'Ja' : 'Nee'}</p>
+                    <h3 class="font-semibold text-gray-800 mt-4 mb-2 border-b pb-1">Objecten (${transport.devices.length})</h3>
+            `;
+            transport.devices.forEach(d => {
+                printContent += `
+                    <div class="text-sm mb-2 p-2 bg-gray-50 rounded">
+                        <p><strong>SN:</strong> ${d.sn || '-'} | <strong>Type:</strong> ${d.type || '-'} | <strong>Hoogte:</strong> ${d.height || '-'} cm</p>
+                        <p><strong>Opmerkingen:</strong> ${d.notes || 'Geen'}</p>
+                    </div>
+                `;
+            });
+            printContent += `</div>`;
+        });
+
+        printContent += `</div>`;
+        if (printableArea) {
+            printableArea.innerHTML = printContent;
+        }
+        window.print();
+    };
+
+    const initDragAndDrop = () => {
+        document.querySelectorAll('[draggable="true"]').forEach(draggable => {
+            draggable.addEventListener('dragstart', e => {
+                e.target.classList.add('dragging');
+                e.dataTransfer.setData('text/plain', e.target.id);
+            });
+            draggable.addEventListener('dragend', e => e.target.classList.remove('dragging'));
+        });
+
+        document.querySelectorAll('.drop-zone, #new-requests-list').forEach(container => {
+            container.addEventListener('dragover', e => {
+                e.preventDefault();
+                container.closest('.truck-bin, .bg-white')?.classList.add('bg-blue-100');
+            });
+            container.addEventListener('dragleave', () => {
+                container.closest('.truck-bin, .bg-white')?.classList.remove('bg-blue-100');
+            });
+            container.addEventListener('drop', e => {
+                e.preventDefault();
+                container.closest('.truck-bin, .bg-white')?.classList.remove('bg-blue-100');
+                const transportId = e.dataTransfer.getData('text/plain');
+                const draggedElement = document.getElementById(transportId);
+                if (draggedElement && !e.currentTarget.contains(draggedElement)) {
+                    const oldTruckId = draggedElement.closest('.truck-bin')?.id;
+                    e.currentTarget.appendChild(draggedElement);
+                    const newTruckId = e.currentTarget.closest('.truck-bin')?.id;
+                    const transport = transports.find(t => t.id === transportId);
+                    if (transport) {
+                        transport.plannedOn = newTruckId || null;
+                        transport.status = newTruckId ? 'Ingepland' : 'Aangevraagd';
+                    }
+                    if (oldTruckId) updateTruckLoad(oldTruckId);
+                    if (newTruckId) updateTruckLoad(newTruckId);
+                    updateAllTruckRoutes();
+                    state.refreshUserList();
+                }
+            });
+        });
+    };
+
+    const syncTruckLayers = () => {
+        if (!map) return;
+        trucks.forEach(truck => {
+            if (!truckRouteLayers[truck.id]) {
+                truckRouteLayers[truck.id] = L.layerGroup().addTo(map);
+            }
+        });
+        Object.keys(truckRouteLayers).forEach(truckId => {
+            if (!trucks.find(t => t.id === truckId)) {
+                truckRouteLayers[truckId].remove();
+                delete truckRouteLayers[truckId];
+            }
+        });
+    };
+
+    const updateTruckRoute = (truckId) => {
+        if (!map) return;
+        if (!truckRouteLayers[truckId]) {
+            truckRouteLayers[truckId] = L.layerGroup().addTo(map);
+        }
+        const layerGroup = truckRouteLayers[truckId];
+        layerGroup.clearLayers();
+        const dropZone = document.querySelector(`#${truckId} .drop-zone`);
+        if (!dropZone) return;
+        const waypoints = [locations['Almere']];
+        dropZone.querySelectorAll('[data-destination]').forEach(req => {
+            const dest = req.dataset.destination;
+            if (locations[dest]) {
+                waypoints.push(locations[dest]);
+                L.marker(locations[dest]).addTo(layerGroup).bindPopup(`${req.id} naar ${dest}`);
+            }
+        });
+        if (waypoints.length > 1) {
+            const color = truckColors[trucks.findIndex(t => t.id === truckId) % truckColors.length];
+            L.polyline(waypoints, { color: color || '#333', weight: 5 }).addTo(layerGroup);
+        }
+    };
+
+    const updateAllTruckRoutes = () => {
+        if (!map) return;
+        trucks.forEach(truck => updateTruckRoute(truck.id));
+    };
+
+    const initMap = () => {
+        if (map) return;
+        map = L.map('map').setView([52.2, 5.5], 8);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '© OpenStreetMap' }).addTo(map);
+        trucks.forEach(truck => {
+            truckRouteLayers[truck.id] = L.layerGroup().addTo(map);
+        });
+        updateAllTruckRoutes();
+    };
+
+    const ensureMap = () => {
+        if (!map) {
+            initMap();
+        } else {
+            setTimeout(() => {
+                map.invalidateSize();
+                updateAllTruckRoutes();
+            }, 1);
+        }
+    };
+
+    const reset = () => {
+        if (map) {
+            map.remove();
+            map = null;
+        }
+        Object.keys(truckRouteLayers).forEach(truckId => {
+            delete truckRouteLayers[truckId];
+        });
+    };
+
+    const removeTruck = (truckId) => {
+        if (truckRouteLayers[truckId]) {
+            truckRouteLayers[truckId].remove();
+            delete truckRouteLayers[truckId];
+        }
+    };
+
+    const renderPlanner = () => {
+        const requestsList = document.getElementById('new-requests-list');
+        const trucksContainer = document.getElementById('trucks-container');
+        if (!requestsList || !trucksContainer) return;
+
+        requestsList.innerHTML = '';
+        trucksContainer.innerHTML = '';
+
+        trucks.forEach(truck => {
+            trucksContainer.innerHTML += `
+                <div id="${truck.id}" class="truck-bin bg-gray-50 p-3 rounded-lg border-2 border-dashed border-gray-300">
+                    <div class="flex justify-between items-center mb-2">
+                        <h4 class="font-semibold flex items-center gap-2">
+                            <i data-lucide="truck"></i>Vrachtwagen (${truck.driver})
+                        </h4>
+                        <div class="flex items-center gap-2">
+                            <span class="text-xs font-mono bg-gray-200 px-2 py-1 rounded">0 / ${truck.capacity}</span>
+                            <button data-action="print-truck-list" data-truck-id="${truck.id}" class="p-1 text-gray-500 hover:text-blue-600" title="Rittenlijst printen">
+                                <i data-lucide="printer" class="w-4 h-4"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="drop-zone min-h-[15vh] space-y-2"></div>
+                </div>
+            `;
+        });
+
+        transports.forEach(t => {
+            const requestHtml = `
+                <div id="${t.id}" draggable="true" data-action="open-transport-details" data-transport-id="${t.id}" data-destination="${t.to}" data-device-count="${t.devices.length}" class="p-3 bg-gray-100 rounded-lg shadow-sm cursor-grab border hover:border-blue-500 transition-colors">
+                    <p class="font-semibold">${t.id}<span class="text-xs font-normal text-gray-500 ml-2">naar ${t.to}</span></p>
+                    <p class="text-sm">${t.devices.length} object(en)</p>
+                </div>
+            `;
+            const targetContainer = t.plannedOn ? document.querySelector(`#${t.plannedOn} .drop-zone`) : (t.status === 'Aangevraagd' ? requestsList : null);
+            if (targetContainer) {
+                targetContainer.insertAdjacentHTML('beforeend', requestHtml);
+            }
+        });
+
+        initDragAndDrop();
+        document.querySelectorAll('.truck-bin').forEach(truckEl => updateTruckLoad(truckEl.id));
+        createIcons();
+        syncTruckLayers();
+        updateAllTruckRoutes();
+    };
+
+    const setRefreshUserList = (fn = noop) => {
+        state.refreshUserList = typeof fn === 'function' ? fn : noop;
+    };
+
+    return {
+        renderView,
+        renderPlanner,
+        updateTruckLoad,
+        printTruckList,
+        ensureMap,
+        reset,
+        removeTruck,
+        setRefreshUserList
+    };
+};

--- a/src/js/portals/userPortal.js
+++ b/src/js/portals/userPortal.js
@@ -1,0 +1,289 @@
+import { transports } from '../database.js';
+
+const noop = () => {};
+
+export const createUserPortal = ({ showNotification, lucide }) => {
+    const state = {
+        onTransportCreated: noop,
+        listenersAttached: false
+    };
+
+    const createIcons = () => {
+        if (lucide && typeof lucide.createIcons === 'function') {
+            lucide.createIcons();
+        }
+    };
+
+    const renderView = (container) => {
+        if (!container) return;
+        container.innerHTML = `
+            <div class="mb-4 border-b border-gray-200">
+                <nav class="flex -mb-px">
+                    <button id="subtab-user-dashboard" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text sub-tab-active">Mijn Transporten</button>
+                    <button id="subtab-user-new" class="sub-tab py-3 px-4 text-sm font-medium text-gray-600 rounded-t-lg hover:text-motrac-blue-text">Nieuwe Aanvraag</button>
+                </nav>
+            </div>
+            <div id="subview-user-dashboard" class="subview-section active">
+                <div class="flex justify-between items-center mb-4">
+                    <h2 class="text-xl font-semibold">Overzicht van mijn transporten</h2>
+                    <button data-action="show-new-request-form" class="motrac-blue text-white font-bold py-2 px-4 rounded-lg flex items-center space-x-2 hover:opacity-90 transition-opacity">
+                        <i data-lucide="plus" class="w-5 h-5"></i>
+                        <span>Nieuwe Aanvraag</span>
+                    </button>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow-sm">
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm text-left">
+                            <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3">Order ID</th>
+                                    <th scope="col" class="px-6 py-3">Van</th>
+                                    <th scope="col" class="px-6 py-3">Naar</th>
+                                    <th scope="col" class="px-6 py-3">Gewenste datum</th>
+                                    <th scope="col" class="px-6 py-3">Status</th>
+                                    <th scope="col" class="px-6 py-3">Acties</th>
+                                </tr>
+                            </thead>
+                            <tbody id="transport-list-body"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div id="subview-user-new" class="subview-section">
+                <h2 class="text-xl font-semibold mb-4">Nieuwe transportaanvraag</h2>
+                <form id="transport-form" class="space-y-8 bg-white p-6 rounded-lg shadow-sm"></form>
+            </div>
+        `;
+        createIcons();
+    };
+
+    const addDeviceRow = (isFirst = false) => {
+        const container = document.getElementById('devices-container');
+        if (!container) return;
+        container.insertAdjacentHTML('beforeend', `
+            <div class="device-row p-4 border rounded-lg bg-gray-50 relative">
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+                    <div>
+                        <label class="text-sm font-medium">Serienummer</label>
+                        <input type="text" name="sn" placeholder="bv. SN12345" class="mt-1 w-full p-2 border rounded-md">
+                    </div>
+                    <div>
+                        <label class="text-sm font-medium">Type</label>
+                        <input type="text" name="type" placeholder="bv. Heftruck" class="mt-1 w-full p-2 border rounded-md">
+                    </div>
+                    <div>
+                        <label class="text-sm font-medium">Hoogte (cm)</label>
+                        <input type="number" name="height" placeholder="220" class="mt-1 w-full p-2 border rounded-md" min="0">
+                    </div>
+                    <div>
+                        <label class="text-sm font-medium">Opmerkingen</label>
+                        <input type="text" name="notes" placeholder="bv. Stickers plakken" class="mt-1 w-full p-2 border rounded-md">
+                    </div>
+                </div>
+                ${!isFirst ? `<button type="button" class="remove-device-btn absolute top-2 right-2 text-gray-400 hover:text-red-600"><i data-lucide="x-circle" class="w-5 h-5"></i></button>` : ''}
+            </div>
+        `);
+        if (!isFirst) {
+            createIcons();
+        }
+    };
+
+    const renderTransportForm = () => {
+        const form = document.getElementById('transport-form');
+        if (!form) return;
+        form.innerHTML = `
+            <div>
+                <h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">1. Locatiegegevens</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label for="from" class="block text-sm font-medium text-gray-700 mb-1">Van</label>
+                        <input type="text" name="from" class="w-full p-2 border rounded-md" value="Rondebeltweg 51, Almere" required>
+                    </div>
+                    <div>
+                        <label for="to" class="block text-sm font-medium text-gray-700 mb-1">Naar</label>
+                        <input type="text" name="to" class="w-full p-2 border rounded-md" placeholder="Adres van klant" required>
+                    </div>
+                </div>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">2. Te Vervoeren Objecten</h3>
+                <div id="devices-container" class="space-y-4"></div>
+                <div class="mt-4">
+                    <button type="button" id="add-device-btn" class="text-sm motrac-blue-text font-semibold hover:underline flex items-center gap-1">
+                        <i data-lucide="plus-circle" class="w-4 h-4"></i>
+                        Extra machine toevoegen
+                    </button>
+                </div>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold border-b pb-2 mb-4 motrac-blue-text">3. Planning en Details</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <label for="date" class="block text-sm font-medium">Gewenste datum</label>
+                        <input type="date" name="date" class="w-full p-2 border rounded-md" required>
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium">Bijzonderheden</label>
+                        <div class="flex items-center">
+                            <input type="checkbox" id="first-job" name="first-job" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                            <label for="first-job" class="ml-2 block text-sm text-gray-900">Eerste werk?</label>
+                        </div>
+                        <div class="flex items-center">
+                            <input type="checkbox" id="loading-dock" name="loading-dock" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                            <label for="loading-dock" class="ml-2 block text-sm text-gray-900">Laaddock aanwezig?</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex justify-end space-x-4 pt-6 border-t">
+                <button type="button" id="cancel-transport-btn" class="bg-gray-200 px-6 py-2 rounded-lg">Annuleren</button>
+                <button type="submit" class="motrac-blue text-white px-6 py-2 rounded-lg">Aanvraag Indienen</button>
+            </div>
+        `;
+        addDeviceRow(true);
+        createIcons();
+    };
+
+    const renderTransportList = () => {
+        const listBody = document.getElementById('transport-list-body');
+        if (!listBody) return;
+        listBody.innerHTML = '';
+        const statusStyles = {
+            'Ingepland': 'bg-blue-100 text-blue-800',
+            'Uitgevoerd': 'bg-green-100 text-green-800',
+            'Aangevraagd': 'bg-yellow-100 text-yellow-800',
+            'Geannuleerd': 'bg-red-100 text-red-800'
+        };
+        transports.forEach(t => {
+            listBody.innerHTML += `
+                <tr class="bg-white border-b">
+                    <td class="px-6 py-4 font-medium">${t.id}</td>
+                    <td class="px-6 py-4">${t.from}</td>
+                    <td class="px-6 py-4">${t.to}</td>
+                    <td class="px-6 py-4">${t.date}</td>
+                    <td class="px-6 py-4">
+                        <span class="${statusStyles[t.status] || ''} text-xs font-medium mr-2 px-2.5 py-0.5 rounded-full">${t.status}</span>
+                    </td>
+                    <td class="px-6 py-4 flex space-x-2">
+                        <button data-action="open-transport-details" data-transport-id="${t.id}" class="p-1 text-gray-500 hover:text-blue-600">
+                            <i data-lucide="eye"></i>
+                        </button>
+                        <button class="p-1 text-gray-500 hover:text-blue-600">
+                            <i data-lucide="pencil"></i>
+                        </button>
+                    </td>
+                </tr>
+            `;
+        });
+        createIcons();
+    };
+
+    const handleTransportSubmit = (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const from = formData.get('from');
+        const to = formData.get('to');
+        const date = formData.get('date');
+
+        const devices = [];
+        let hasInvalidHeight = false;
+        document.querySelectorAll('.device-row').forEach(row => {
+            const sn = row.querySelector('input[name="sn"]').value;
+            const type = row.querySelector('input[name="type"]').value;
+            const height = row.querySelector('input[name="height"]').value;
+            const notes = row.querySelector('input[name="notes"]').value;
+
+            if (parseFloat(height) < 0) {
+                showNotification('De hoogte van een object kan niet negatief zijn.', 'error');
+                hasInvalidHeight = true;
+                return;
+            }
+
+            if (sn || type) {
+                devices.push({ sn, type, height, notes });
+            }
+        });
+
+        if (hasInvalidHeight) return;
+
+        if (!from || !to || !date || devices.length === 0) {
+            showNotification('Vul alle locatie/datum velden en tenminste één object in.', 'error');
+            return;
+        }
+
+        const newId = 'TR-' + (Math.floor(Math.random() * 9000) + 1000);
+        transports.push({
+            id: newId,
+            from,
+            to,
+            date,
+            status: 'Aangevraagd',
+            plannedOn: null,
+            devices,
+            details: {
+                firstJob: document.getElementById('first-job').checked,
+                loadingDock: document.getElementById('loading-dock').checked
+            }
+        });
+
+        showNotification(`Transport ${newId} succesvol aangevraagd!`);
+        e.target.reset();
+        const devicesContainer = document.getElementById('devices-container');
+        if (devicesContainer) {
+            devicesContainer.innerHTML = '';
+        }
+        addDeviceRow(true);
+        renderTransportList();
+        state.onTransportCreated();
+        const dashboardTab = document.getElementById('subtab-user-dashboard');
+        if (dashboardTab) {
+            dashboardTab.click();
+        }
+    };
+
+    const attachListeners = () => {
+        if (state.listenersAttached) return;
+        const userView = document.getElementById('view-user');
+        if (!userView) return;
+
+        userView.addEventListener('submit', e => {
+            if (e.target.id === 'transport-form') {
+                handleTransportSubmit(e);
+            }
+        });
+
+        userView.addEventListener('click', e => {
+            if (e.target.closest('#add-device-btn')) {
+                addDeviceRow();
+            }
+            if (e.target.id === 'cancel-transport-btn') {
+                const dashboardTab = document.getElementById('subtab-user-dashboard');
+                if (dashboardTab) {
+                    dashboardTab.click();
+                }
+            }
+            if (e.target.closest('.remove-device-btn')) {
+                const row = e.target.closest('.device-row');
+                if (row) {
+                    row.remove();
+                }
+            }
+        });
+
+        state.listenersAttached = true;
+    };
+
+    const setOnTransportCreated = (fn = noop) => {
+        state.onTransportCreated = typeof fn === 'function' ? fn : noop;
+    };
+
+    return {
+        renderView,
+        renderTransportForm,
+        renderTransportList,
+        handleTransportSubmit,
+        addDeviceRow,
+        attachListeners,
+        setOnTransportCreated
+    };
+};


### PR DESCRIPTION
## Summary
- extract the user portal rendering and transport submission logic into `userPortal.js`
- move planner dashboard, drag-and-drop, and map management into `plannerPortal.js`
- update the main app bootstrap to wire the new modules, simplify event handlers, and keep admin rendering intact

## Testing
- not run (UI-focused changes)

------
https://chatgpt.com/codex/tasks/task_e_68d4256e2df0832b85f5c0580f9f05dd