### PR TITLE
Breid transportplanner uit met vrachtwagenplanning

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">HTML + Supabase (client-side). Maak orders aan, plan carriers en bewaak deadlines.</div>
+    <div class="sub">Complete workflow voor transportaanvragen, vrachtwagenbeheer en planning.</div>
   </header>
 
   <main class="wrap">
@@ -74,15 +74,21 @@
     <section class="content">
       <section class="card">
         <div class="bar">
-          <h3>Nieuwe order</h3>
+          <h3>Nieuwe transportaanvraag</h3>
           <button id="btnReload" class="btn ghost">Vernieuwen</button>
         </div>
         <div class="grid2">
+          <label>Referentie
+            <input id="oReference" placeholder="Bijv. ORD-2024-001" />
+          </label>
           <label>Klantnaam
             <input id="oCustomer" placeholder="Klant BV" />
           </label>
-          <label>Stad
+          <label>Stad klant
             <input id="oCity" placeholder="Plaatsnaam" />
+          </label>
+          <label>Contactpersoon
+            <input id="oContact" placeholder="Naam + telefoon" />
           </label>
           <label>Regio
             <select id="oRegion">
@@ -92,15 +98,76 @@
           <label>Prioriteit (1–5)
             <input id="oPriority" type="number" min="1" max="5" value="3" />
           </label>
-          <label>Gevraagde datum
+          <label>Gewenste leverdatum
             <input id="oDue" type="date" />
           </label>
-          <label>Opmerkingen
-            <input id="oNotes" placeholder="Bijzonderheden, aanmeldprocedure…" />
+          <label>Type transport
+            <select id="oLoadType">
+              <option value="">Selecteer...</option>
+              <option>Complete lading</option>
+              <option>Deellading</option>
+              <option>Koeltransport</option>
+              <option>ADR</option>
+            </select>
           </label>
         </div>
+
+        <h4 class="section-title">Laadadres</h4>
+        <div class="grid3">
+          <label>Locatie
+            <input id="oPickupLocation" placeholder="Straat + plaats" />
+          </label>
+          <label>Datum
+            <input id="oPickupDate" type="date" />
+          </label>
+          <label>Tijdslot
+            <select id="oPickupSlot">
+              <option value="">n.v.t.</option>
+              <option>07:00 - 09:00</option>
+              <option>09:00 - 12:00</option>
+              <option>12:00 - 15:00</option>
+              <option>15:00 - 18:00</option>
+            </select>
+          </label>
+        </div>
+
+        <h4 class="section-title">Losadres</h4>
+        <div class="grid3">
+          <label>Locatie
+            <input id="oDeliveryLocation" placeholder="Straat + plaats" />
+          </label>
+          <label>Datum
+            <input id="oDeliveryDate" type="date" />
+          </label>
+          <label>Tijdslot
+            <select id="oDeliverySlot">
+              <option value="">n.v.t.</option>
+              <option>07:00 - 09:00</option>
+              <option>09:00 - 12:00</option>
+              <option>12:00 - 15:00</option>
+              <option>15:00 - 18:00</option>
+            </select>
+          </label>
+        </div>
+
+        <h4 class="section-title">Lading</h4>
+        <div class="grid4">
+          <label>Pallets
+            <input id="oPallets" type="number" min="0" step="1" />
+          </label>
+          <label>Gewicht (kg)
+            <input id="oWeight" type="number" min="0" step="0.1" />
+          </label>
+          <label>Volume (m³)
+            <input id="oVolume" type="number" min="0" step="0.1" />
+          </label>
+          <label>Opmerkingen
+            <textarea id="oNotes" rows="2" placeholder="Bijzonderheden, aanmeldprocedure…"></textarea>
+          </label>
+        </div>
+
         <details>
-          <summary>Regel(s) toevoegen (optioneel)</summary>
+          <summary>Extra orderregel toevoegen (optioneel)</summary>
           <div class="grid3">
             <label>Product
               <input id="lProduct" placeholder="Heftruck, pallet, etc." />
@@ -113,24 +180,87 @@
             </label>
           </div>
         </details>
-        <button id="btnCreate" class="btn primary">Order aanmaken</button>
+        <button id="btnCreate" class="btn primary">Transport opslaan</button>
         <div id="createStatus" class="status"></div>
       </section>
 
       <section class="card">
         <div class="bar">
+          <h3>Vrachtwagenbeheer</h3>
+          <span class="muted small">Wordt lokaal opgeslagen voor de planner.</span>
+        </div>
+        <div class="grid4">
+          <label>Naam voertuig
+            <input id="truckName" placeholder="Bijv. Truck 01" />
+          </label>
+          <label>Kenteken
+            <input id="truckPlate" placeholder="00-XX-00" />
+          </label>
+          <label>Chauffeur
+            <input id="truckDriver" placeholder="Naam chauffeur" />
+          </label>
+          <label>Stops per dag
+            <input id="truckCapacity" type="number" min="1" value="6" />
+          </label>
+        </div>
+        <button id="btnAddTruck" class="btn">Vrachtwagen opslaan</button>
+        <div id="truckStatus" class="status"></div>
+        <ul id="truckList" class="truck-list"></ul>
+      </section>
+
+      <section class="card">
+        <div class="bar">
+          <h3>Planbord</h3>
+          <button id="btnClearBoard" class="btn ghost">Wis planning voor gekozen dag</button>
+        </div>
+        <div class="grid4 board-controls">
+          <label>Planningsdatum
+            <input id="boardDate" type="date" />
+          </label>
+          <label>Vrachtwagen
+            <select id="boardTruck"></select>
+          </label>
+          <label>Transport
+            <select id="boardOrder"></select>
+          </label>
+          <label>Tijdslot
+            <select id="boardSlot">
+              <option value="">n.v.t.</option>
+              <option>AM</option>
+              <option>PM</option>
+              <option>Nacht</option>
+            </select>
+          </label>
+        </div>
+        <div class="board-actions">
+          <button id="btnAssignOrder" class="btn primary">Plan transport in vrachtwagen</button>
+          <div id="boardStatus" class="status"></div>
+        </div>
+        <div id="planBoard" class="board-grid"></div>
+      </section>
+
+      <section class="card">
+        <div class="bar">
           <h3>Orders</h3>
-          <div class="muted small">Klik op een regel om te bewerken (carrier, datum, status).</div>
+          <div class="muted small">Klik op een regel om te bewerken (carrier, datum, status). Details worden getoond in de tooltip.</div>
         </div>
         <div class="table-wrap">
           <table id="ordersTable">
             <thead>
               <tr>
-                <th>Due</th><th>Klant</th><th>Regio</th><th>Prioriteit</th><th>Status</th><th>Carrier</th><th>Gepland</th>
+                <th>Leverdatum</th>
+                <th>Referentie</th>
+                <th>Klant</th>
+                <th>Laadadres</th>
+                <th>Losadres</th>
+                <th>Lading</th>
+                <th>Status</th>
+                <th>Vrachtwagen</th>
+                <th>Gepland</th>
               </tr>
             </thead>
             <tbody>
-              <tr><td colspan="7" class="muted">Nog niets geladen…</td></tr>
+              <tr><td colspan="9" class="muted">Nog niets geladen…</td></tr>
             </tbody>
           </table>
         </div>
@@ -154,7 +284,7 @@
             <option>Geannuleerd</option>
           </select>
         </label>
-        <label>Carrier
+        <label>Carrier / vrachtwagen
           <input id="eCarrier" placeholder="Bijv. Beekman Transport" list="carrierList"/>
           <datalist id="carrierList"></datalist>
         </label>
@@ -164,7 +294,7 @@
         <label>Tijdslot
           <select id="eSlot">
             <option value="">n.v.t.</option>
-            <option>AM</option><option>PM</option>
+            <option>AM</option><option>PM</option><option>Nacht</option>
           </select>
         </label>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -12,11 +12,23 @@ const els = {
   quickRegion: document.getElementById("quickRegion"),
   btnAddCarrier: document.getElementById("btnAddCarrier"),
   carrierStatus: document.getElementById("carrierStatus"),
+  oReference: document.getElementById("oReference"),
   oCustomer: document.getElementById("oCustomer"),
   oCity: document.getElementById("oCity"),
+  oContact: document.getElementById("oContact"),
   oRegion: document.getElementById("oRegion"),
   oPriority: document.getElementById("oPriority"),
   oDue: document.getElementById("oDue"),
+  oLoadType: document.getElementById("oLoadType"),
+  oPickupLocation: document.getElementById("oPickupLocation"),
+  oPickupDate: document.getElementById("oPickupDate"),
+  oPickupSlot: document.getElementById("oPickupSlot"),
+  oDeliveryLocation: document.getElementById("oDeliveryLocation"),
+  oDeliveryDate: document.getElementById("oDeliveryDate"),
+  oDeliverySlot: document.getElementById("oDeliverySlot"),
+  oPallets: document.getElementById("oPallets"),
+  oWeight: document.getElementById("oWeight"),
+  oVolume: document.getElementById("oVolume"),
   oNotes: document.getElementById("oNotes"),
   lProduct: document.getElementById("lProduct"),
   lQty: document.getElementById("lQty"),
@@ -33,10 +45,158 @@ const els = {
   eSlot: document.getElementById("eSlot"),
   btnSaveEdit: document.getElementById("btnSaveEdit"),
   carrierList: document.getElementById("carrierList"),
+  truckName: document.getElementById("truckName"),
+  truckPlate: document.getElementById("truckPlate"),
+  truckDriver: document.getElementById("truckDriver"),
+  truckCapacity: document.getElementById("truckCapacity"),
+  btnAddTruck: document.getElementById("btnAddTruck"),
+  truckStatus: document.getElementById("truckStatus"),
+  truckList: document.getElementById("truckList"),
+  boardDate: document.getElementById("boardDate"),
+  boardTruck: document.getElementById("boardTruck"),
+  boardOrder: document.getElementById("boardOrder"),
+  boardSlot: document.getElementById("boardSlot"),
+  btnAssignOrder: document.getElementById("btnAssignOrder"),
+  boardStatus: document.getElementById("boardStatus"),
+  btnClearBoard: document.getElementById("btnClearBoard"),
+  planBoard: document.getElementById("planBoard"),
 };
+
+const STORAGE_KEYS = {
+  trucks: "transport_trucks_v1",
+  board: "transport_board_v1",
+};
+
+const STORAGE_AVAILABLE = (() => {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return false;
+    const testKey = "__transport_test__";
+    window.localStorage.setItem(testKey, testKey);
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();
+
+function storageGet(key, fallback) {
+  if (!STORAGE_AVAILABLE) return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch (e) {
+    console.warn("Kan localStorage niet lezen", e);
+    return fallback;
+  }
+}
+
+function storageSet(key, value) {
+  if (!STORAGE_AVAILABLE) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (e) {
+    console.warn("Kan localStorage niet schrijven", e);
+  }
+}
+
+function randomId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `truck-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
 
 let ORDERS_CACHE = [];
 let PLAN_SUGGESTIONS = [];
+let TRUCKS = [];
+let PLAN_BOARD = {};
+
+function hydrateLocalState() {
+  TRUCKS = storageGet(STORAGE_KEYS.trucks, []);
+  PLAN_BOARD = storageGet(STORAGE_KEYS.board, {});
+}
+
+function saveTrucks() {
+  storageSet(STORAGE_KEYS.trucks, TRUCKS);
+}
+
+function savePlanBoard() {
+  storageSet(STORAGE_KEYS.board, PLAN_BOARD);
+}
+
+function parseOrderDetails(order) {
+  const base = {
+    reference: null,
+    pickup: null,
+    delivery: null,
+    cargo: {},
+    instructions: null,
+    contact: null,
+  };
+  if (!order) return base;
+  const raw = order.notes;
+  if (raw && typeof raw === "string" && raw.startsWith("JSON:")) {
+    try {
+      const parsed = JSON.parse(raw.slice(5));
+      Object.assign(base, {
+        reference: parsed.reference ?? null,
+        pickup: parsed.pickup ?? null,
+        delivery: parsed.delivery ?? null,
+        cargo: parsed.cargo ?? {},
+        instructions: parsed.instructions ?? null,
+        contact: parsed.contact ?? null,
+      });
+    } catch (e) {
+      console.warn("Kan orderdetails niet parsen", e);
+      base.instructions = raw;
+    }
+  } else if (raw) {
+    base.instructions = raw;
+  }
+  if (!base.pickup && order.customer_city) {
+    base.pickup = { location: order.customer_city };
+  }
+  if (!base.delivery && order.customer_city) {
+    base.delivery = { location: order.customer_city };
+  }
+  if (!base.contact && order.customer_contact) {
+    base.contact = order.customer_contact;
+  }
+  return base;
+}
+
+function formatStop(stop) {
+  if (!stop) return "-";
+  const parts = [];
+  if (stop.location) parts.push(stop.location);
+  if (stop.date) parts.push(stop.date);
+  if (stop.slot) parts.push(stop.slot);
+  return parts.length ? parts.join(" • ") : "-";
+}
+
+function formatCargo(cargo) {
+  if (!cargo) return "-";
+  const parts = [];
+  if (cargo.type) parts.push(cargo.type);
+  if (cargo.pallets) parts.push(`${cargo.pallets} pallets`);
+  if (cargo.weight) parts.push(`${cargo.weight} kg`);
+  if (cargo.volume) parts.push(`${cargo.volume} m³`);
+  return parts.length ? parts.join(" • ") : "-";
+}
+
+function formatPlanned(row) {
+  const parts = [];
+  if (row.planned_date) parts.push(row.planned_date);
+  if (row.planned_slot) parts.push(`(${row.planned_slot})`);
+  return parts.join(" ") || "-";
+}
+
+function formatDateDisplay(value) {
+  if (!value) return "-";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString("nl-NL", { weekday: "short", day: "2-digit", month: "2-digit" });
+}
 
 async function refreshCarriersDatalist() {
   const carriers = await Carriers.list();
@@ -51,25 +211,35 @@ async function loadOrders() {
   const rows = await Orders.list(filters);
   ORDERS_CACHE = rows;
   renderOrders(rows);
+  updatePlanBoardSelectors();
+  syncPlanBoardFromOrders();
+  renderPlanBoard();
 }
 
 function renderOrders(rows) {
   const tbody = els.ordersTable;
   tbody.innerHTML = "";
   if (!rows.length) {
-    tbody.innerHTML = '<tr><td colspan="7" class="muted">Geen orders gevonden</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="9" class="muted">Geen orders gevonden</td></tr>';
     return;
   }
   for (const r of rows) {
+    const details = parseOrderDetails(r);
     const tr = document.createElement("tr");
+    const tooltip = [];
+    if (details.instructions) tooltip.push(`Instructies: ${details.instructions}`);
+    if (details.contact) tooltip.push(`Contact: ${details.contact}`);
+    tr.title = tooltip.join("\n");
     tr.innerHTML = `
-      <td>${r.due_date ?? "-"}</td>
+      <td>${r.due_date ?? details.delivery?.date ?? "-"}</td>
+      <td>${details.reference ?? "-"}</td>
       <td>${r.customer_name ?? "-"}</td>
-      <td>${r.region ?? "-"}</td>
-      <td>${r.priority ?? "-"}</td>
+      <td>${formatStop(details.pickup)}</td>
+      <td>${formatStop(details.delivery)}</td>
+      <td>${formatCargo(details.cargo)}</td>
       <td>${r.status ?? "-"}</td>
       <td>${r.assigned_carrier ?? "-"}</td>
-      <td>${r.planned_date ?? "-"}</td>
+      <td>${formatPlanned(r)}</td>
     `;
     tr.addEventListener("click", () => openEdit(r));
     tbody.appendChild(tr);
@@ -99,16 +269,66 @@ async function saveEdit(){
   await loadOrders();
 }
 
+function readNumber(value) {
+  const num = parseFloat(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function buildOrderDetails() {
+  return {
+    reference: els.oReference.value.trim() || null,
+    pickup: {
+      location: els.oPickupLocation.value.trim() || null,
+      date: els.oPickupDate.value || null,
+      slot: els.oPickupSlot.value || null,
+    },
+    delivery: {
+      location: els.oDeliveryLocation.value.trim() || null,
+      date: els.oDeliveryDate.value || els.oDue.value || null,
+      slot: els.oDeliverySlot.value || null,
+    },
+    cargo: {
+      type: els.oLoadType.value || null,
+      pallets: els.oPallets.value ? parseInt(els.oPallets.value, 10) : null,
+      weight: readNumber(els.oWeight.value),
+      volume: readNumber(els.oVolume.value),
+    },
+    contact: els.oContact.value.trim() || null,
+    instructions: els.oNotes.value.trim() || null,
+  };
+}
+
+function resetOrderForm(){
+  [
+    "oReference","oCustomer","oCity","oContact","oPriority","oDue","oLoadType",
+    "oPickupLocation","oPickupDate","oPickupSlot","oDeliveryLocation","oDeliveryDate",
+    "oDeliverySlot","oPallets","oWeight","oVolume","oNotes","lProduct","lQty","lWeight"
+  ].forEach(id => {
+    const field = document.getElementById(id);
+    if (!field) return;
+    if (field.tagName === "SELECT") {
+      field.selectedIndex = 0;
+    } else {
+      field.value = "";
+    }
+  });
+  els.oRegion.selectedIndex = 0;
+  els.oPriority.value = "3";
+  els.lQty.value = "1";
+  els.lWeight.value = "0";
+}
+
 async function createOrder(){
   els.createStatus.textContent = "Bezig…";
   try {
+    const details = buildOrderDetails();
     const order = {
       customer_name: els.oCustomer.value.trim(),
       customer_city: els.oCity.value.trim(),
       region: els.oRegion.value,
       priority: parseInt(els.oPriority.value || "3", 10),
-      due_date: els.oDue.value || null,
-      notes: els.oNotes.value.trim() || null,
+      due_date: details.delivery?.date || els.oDue.value || null,
+      notes: "JSON:" + JSON.stringify(details),
       status: "Nieuw",
     };
     const created = await Orders.create(order);
@@ -120,8 +340,8 @@ async function createOrder(){
         weight_kg: parseFloat(els.lWeight.value || "0")
       });
     }
-    els.createStatus.textContent = "Aangemaakt";
-    ["oCustomer","oCity","oPriority","oDue","oNotes","lProduct","lQty","lWeight"].forEach(id => document.getElementById(id).value = "");
+    els.createStatus.textContent = "Transport aangemaakt";
+    resetOrderForm();
     await loadOrders();
   } catch (e) {
     console.error(e);
@@ -147,6 +367,355 @@ async function addCarrier(){
   }
 }
 
+function renderTrucks(){
+  const list = els.truckList;
+  list.innerHTML = "";
+  if (!TRUCKS.length){
+    const li = document.createElement("li");
+    li.className = "empty-hint";
+    li.textContent = "Nog geen voertuigen opgeslagen.";
+    list.appendChild(li);
+  } else {
+    for (const truck of TRUCKS){
+      const li = document.createElement("li");
+      const header = document.createElement("header");
+      const title = document.createElement("strong");
+      title.textContent = truck.name;
+      header.appendChild(title);
+      const removeBtn = document.createElement("button");
+      removeBtn.className = "btn ghost small";
+      removeBtn.textContent = "Verwijderen";
+      removeBtn.addEventListener("click", () => removeTruck(truck.id));
+      header.appendChild(removeBtn);
+      li.appendChild(header);
+      const meta = document.createElement("div");
+      meta.className = "truck-meta";
+      const metaParts = [];
+      if (truck.plate) metaParts.push(`Kenteken ${truck.plate}`);
+      if (truck.driver) metaParts.push(`Chauffeur ${truck.driver}`);
+      metaParts.push(`${truck.capacity || "∞"} stops/dag`);
+      meta.textContent = metaParts.join(" • ");
+      li.appendChild(meta);
+      list.appendChild(li);
+    }
+  }
+  updatePlanBoardSelectors();
+  renderPlanBoard();
+}
+
+function addTruck(){
+  const name = els.truckName.value.trim();
+  if (!name){
+    els.truckStatus.textContent = "Vul een naam in.";
+    return;
+  }
+  const truck = {
+    id: randomId(),
+    name,
+    plate: els.truckPlate.value.trim(),
+    driver: els.truckDriver.value.trim(),
+    capacity: parseInt(els.truckCapacity.value || "6", 10)
+  };
+  TRUCKS.push(truck);
+  saveTrucks();
+  els.truckStatus.textContent = `${truck.name} opgeslagen.`;
+  ["truckName","truckPlate","truckDriver"].forEach(id => { const el = document.getElementById(id); if (el) el.value = ""; });
+  els.truckCapacity.value = "6";
+  renderTrucks();
+}
+
+async function removeTruck(id){
+  const truck = TRUCKS.find(t => t.id === id);
+  TRUCKS = TRUCKS.filter(t => t.id !== id);
+  saveTrucks();
+  for (const date of Object.keys(PLAN_BOARD)){
+    if (PLAN_BOARD[date][id]){
+      delete PLAN_BOARD[date][id];
+      if (!Object.keys(PLAN_BOARD[date]).length){
+        delete PLAN_BOARD[date];
+      }
+    }
+  }
+  savePlanBoard();
+  renderTrucks();
+  els.boardStatus.textContent = truck ? `Planning voor ${truck.name} verwijderd.` : "Vrachtwagen verwijderd.";
+  await loadOrders();
+}
+
+function updatePlanBoardSelectors(){
+  const truckSelect = els.boardTruck;
+  truckSelect.innerHTML = '<option value="">Selecteer vrachtwagen…</option>';
+  for (const truck of TRUCKS){
+    const option = document.createElement("option");
+    option.value = truck.id;
+    option.textContent = `${truck.name} (${truck.capacity || "∞"} stops)`;
+    truckSelect.appendChild(option);
+  }
+  const orderSelect = els.boardOrder;
+  orderSelect.innerHTML = '<option value="">Selecteer transport…</option>';
+  const eligible = ORDERS_CACHE.filter(o => !["Geleverd","Geannuleerd"].includes(o.status || ""));
+  eligible.sort((a,b) => (a.due_date || "").localeCompare(b.due_date || ""));
+  for (const order of eligible){
+    const details = parseOrderDetails(order);
+    const option = document.createElement("option");
+    option.value = order.id;
+    const parts = [];
+    parts.push(details.reference || order.customer_name || `Order #${order.id}`);
+    if (order.customer_name) parts.push(order.customer_name);
+    const due = order.due_date || details.delivery?.date;
+    if (due) parts.push(due);
+    option.textContent = parts.join(" • ");
+    orderSelect.appendChild(option);
+  }
+}
+
+function syncPlanBoardFromOrders(){
+  let changed = false;
+  const cleaned = {};
+  for (const [date, trucks] of Object.entries(PLAN_BOARD)){
+    const newTrucks = {};
+    for (const [truckId, assignments] of Object.entries(trucks)){
+      const truck = TRUCKS.find(t => t.id === truckId);
+      if (!truck) {
+        changed = true;
+        continue;
+      }
+      const filtered = assignments.filter(assignment => {
+        const order = ORDERS_CACHE.find(o => o.id === assignment.orderId);
+        if (!order) return false;
+        if (order.planned_date && order.planned_date !== date) return false;
+        if (order.assigned_carrier && order.assigned_carrier !== truck.name) return false;
+        return true;
+      }).map(assignment => {
+        const order = ORDERS_CACHE.find(o => o.id === assignment.orderId);
+        const details = order ? parseOrderDetails(order) : assignment.details || {};
+        return {
+          ...assignment,
+          reference: details.reference || order?.customer_name || assignment.reference,
+          details,
+        };
+      });
+      if (filtered.length){
+        newTrucks[truckId] = filtered;
+      } else if (assignments.length){
+        changed = true;
+      }
+    }
+    if (Object.keys(newTrucks).length){
+      cleaned[date] = newTrucks;
+    } else if (Object.keys(trucks).length){
+      changed = true;
+    }
+  }
+  if (changed){
+    PLAN_BOARD = cleaned;
+    savePlanBoard();
+  }
+}
+
+function renderPlanBoard(){
+  const container = els.planBoard;
+  container.innerHTML = "";
+  let date = els.boardDate.value;
+  if (!date){
+    date = new Date().toISOString().slice(0,10);
+    els.boardDate.value = date;
+  }
+  if (!TRUCKS.length){
+    container.innerHTML = '<div class="empty-hint">Voeg eerst vrachtwagens toe om te plannen.</div>';
+    els.boardStatus.textContent = "Geen vrachtwagens beschikbaar.";
+    return;
+  }
+  const dayData = PLAN_BOARD[date] || {};
+  let total = 0;
+  for (const truck of TRUCKS){
+    const card = document.createElement("div");
+    card.className = "truck-card";
+    const header = document.createElement("header");
+    const title = document.createElement("strong");
+    title.textContent = truck.name;
+    header.appendChild(title);
+    const capacity = document.createElement("span");
+    capacity.className = "badge";
+    const used = (dayData[truck.id] || []).length;
+    capacity.textContent = `${used}/${truck.capacity || "∞"}`;
+    header.appendChild(capacity);
+    card.appendChild(header);
+
+    const meta = document.createElement("div");
+    meta.className = "truck-meta";
+    const metaParts = [];
+    if (truck.plate) metaParts.push(`Kenteken ${truck.plate}`);
+    if (truck.driver) metaParts.push(`Chauffeur ${truck.driver}`);
+    meta.textContent = metaParts.join(" • ") || "Geen aanvullende info";
+    card.appendChild(meta);
+
+    const assignments = (dayData[truck.id] || []).slice().sort((a,b) => {
+      return (a.slot || "zzz").localeCompare(b.slot || "zzz") || (a.reference || "").localeCompare(b.reference || "");
+    });
+
+    if (!assignments.length){
+      const empty = document.createElement("div");
+      empty.className = "empty-hint";
+      empty.textContent = "Nog geen transporten ingepland.";
+      card.appendChild(empty);
+    } else {
+      for (const assignment of assignments){
+        const order = ORDERS_CACHE.find(o => o.id === assignment.orderId);
+        const details = order ? parseOrderDetails(order) : assignment.details || {};
+        const item = document.createElement("div");
+        item.className = "assignment";
+        const titleLine = document.createElement("strong");
+        titleLine.textContent = details.reference || order?.customer_name || `Order #${assignment.orderId}`;
+        item.appendChild(titleLine);
+        const customerLine = document.createElement("div");
+        customerLine.textContent = order?.customer_name || assignment.customer || "";
+        item.appendChild(customerLine);
+        const routeLine = document.createElement("div");
+        routeLine.className = "truck-meta";
+        routeLine.textContent = `${formatStop(details.pickup)} → ${formatStop(details.delivery)}`;
+        item.appendChild(routeLine);
+        const cargoText = formatCargo(details.cargo);
+        if (cargoText && cargoText !== "-"){
+          const cargoLine = document.createElement("div");
+          cargoLine.className = "truck-meta";
+          cargoLine.textContent = cargoText;
+          item.appendChild(cargoLine);
+        }
+        if (assignment.slot){
+          const slotTag = document.createElement("span");
+          slotTag.className = "tag";
+          slotTag.textContent = assignment.slot;
+          item.appendChild(slotTag);
+        }
+        if (details.instructions){
+          item.title = details.instructions;
+        }
+        const actions = document.createElement("div");
+        actions.style.display = "flex";
+        actions.style.gap = "8px";
+        const removeBtn = document.createElement("button");
+        removeBtn.className = "btn ghost small";
+        removeBtn.textContent = "Verwijderen";
+        removeBtn.addEventListener("click", () => removeAssignment(date, truck.id, assignment.orderId));
+        actions.appendChild(removeBtn);
+        item.appendChild(actions);
+        card.appendChild(item);
+      }
+      total += assignments.length;
+    }
+    container.appendChild(card);
+  }
+  els.boardStatus.textContent = `${total} transport(en) ingepland op ${formatDateDisplay(date)}.`;
+}
+
+async function assignOrderToTruck(){
+  if (!els.boardDate.value){
+    els.boardStatus.textContent = "Selecteer een datum.";
+    return;
+  }
+  const truckId = els.boardTruck.value;
+  const orderId = parseInt(els.boardOrder.value || "0", 10);
+  if (!truckId || !orderId){
+    els.boardStatus.textContent = "Kies zowel een vrachtwagen als een transport.";
+    return;
+  }
+  const truck = TRUCKS.find(t => t.id === truckId);
+  const order = ORDERS_CACHE.find(o => o.id === orderId);
+  if (!truck || !order){
+    els.boardStatus.textContent = "Onbekende selectie.";
+    return;
+  }
+  const date = els.boardDate.value;
+  if (!PLAN_BOARD[date]) PLAN_BOARD[date] = {};
+  if (!PLAN_BOARD[date][truckId]) PLAN_BOARD[date][truckId] = [];
+  if (PLAN_BOARD[date][truckId].some(a => a.orderId === orderId)){
+    els.boardStatus.textContent = "Transport staat al ingepland op deze vrachtwagen.";
+    return;
+  }
+  if (truck.capacity && PLAN_BOARD[date][truckId].length >= truck.capacity){
+    els.boardStatus.textContent = `${truck.name} heeft de maximale capaciteit bereikt.`;
+    return;
+  }
+  const details = parseOrderDetails(order);
+  PLAN_BOARD[date][truckId].push({
+    orderId,
+    reference: details.reference || order.customer_name,
+    customer: order.customer_name,
+    slot: els.boardSlot.value || null,
+    details
+  });
+  savePlanBoard();
+  els.boardStatus.textContent = `Transport toegewezen aan ${truck.name}.`;
+  els.boardOrder.value = "";
+  renderPlanBoard();
+  try {
+    await Orders.update(orderId, {
+      status: "Gepland",
+      assigned_carrier: truck.name,
+      planned_date: date,
+      planned_slot: els.boardSlot.value || null,
+      updated_at: new Date().toISOString()
+    });
+    await loadOrders();
+  } catch (e) {
+    console.error(e);
+    els.boardStatus.textContent = "Planning opgeslagen maar synchronisatie met database mislukte.";
+  }
+}
+
+async function removeAssignment(date, truckId, orderId){
+  if (!PLAN_BOARD[date] || !PLAN_BOARD[date][truckId]) return;
+  PLAN_BOARD[date][truckId] = PLAN_BOARD[date][truckId].filter(a => a.orderId !== orderId);
+  if (!PLAN_BOARD[date][truckId].length){
+    delete PLAN_BOARD[date][truckId];
+  }
+  if (!Object.keys(PLAN_BOARD[date]).length){
+    delete PLAN_BOARD[date];
+  }
+  savePlanBoard();
+  renderPlanBoard();
+  els.boardStatus.textContent = "Transport verwijderd uit planning.";
+  try {
+    await Orders.update(orderId, {
+      status: "Te plannen",
+      assigned_carrier: null,
+      planned_date: null,
+      planned_slot: null,
+      updated_at: new Date().toISOString()
+    });
+    await loadOrders();
+  } catch (e) {
+    console.error(e);
+    els.boardStatus.textContent = "Planning lokaal bijgewerkt, maar synchronisatie mislukte.";
+  }
+}
+
+async function clearBoardForDay(){
+  const date = els.boardDate.value;
+  if (!date || !PLAN_BOARD[date]){
+    els.boardStatus.textContent = "Geen planning voor deze datum.";
+    return;
+  }
+  const affectedAssignments = Object.values(PLAN_BOARD[date]).flat();
+  delete PLAN_BOARD[date];
+  savePlanBoard();
+  renderPlanBoard();
+  els.boardStatus.textContent = "Planning gewist.";
+  try {
+    await Promise.allSettled(affectedAssignments.map(a => Orders.update(a.orderId, {
+      status: "Te plannen",
+      assigned_carrier: null,
+      planned_date: null,
+      planned_slot: null,
+      updated_at: new Date().toISOString()
+    })));
+    await loadOrders();
+  } catch (e) {
+    console.error(e);
+  }
+}
+
 async function suggestPlan(){
   els.plannerStatus.textContent = "Voorstel maken…";
   const carriers = await Carriers.list();
@@ -168,9 +737,10 @@ async function suggestPlan(){
   openOrders.sort((a,b) => (b.priority||0)-(a.priority||0) || (a.due_date||"").localeCompare(b.due_date||""));
   const suggestions = [];
   for (const o of openOrders){
+    const details = parseOrderDetails(o);
     const regionCarriers = active.filter(c => (c.base_region||"") === (o.region||""));
     const allTry = regionCarriers.length ? regionCarriers : active;
-    const pref = o.due_date || dates[0];
+    const pref = details.delivery?.date || o.due_date || dates[0];
     const tryDates = Array.from(new Set([pref, ...dates]));
     let assigned = false;
     for (const day of tryDates){
@@ -195,7 +765,7 @@ async function suggestPlan(){
 
 async function applyPlan(){
   els.plannerStatus.textContent = "Opslaan…";
-  const tasks = PLAN_SUGGESTIONS.filter(s => s.carrier && s.date).map(s => 
+  const tasks = PLAN_SUGGESTIONS.filter(s => s.carrier && s.date).map(s =>
     Orders.update(s.id, {
       status: "Gepland",
       assigned_carrier: s.carrier,
@@ -217,14 +787,21 @@ function bind(){
   els.btnSuggestPlan.addEventListener("click", suggestPlan);
   els.btnApplyPlan.addEventListener("click", applyPlan);
   els.btnSaveEdit.addEventListener("click", (e)=>{ e.preventDefault(); saveEdit(); });
+  els.btnAddTruck.addEventListener("click", addTruck);
+  els.btnAssignOrder.addEventListener("click", assignOrderToTruck);
+  els.btnClearBoard.addEventListener("click", clearBoardForDay);
+  els.boardDate.addEventListener("change", () => { renderPlanBoard(); });
 }
 
 (async function init(){
   bind();
+  hydrateLocalState();
   const today = new Date();
   const end = new Date(Date.now()+5*86400000);
   els.planStart.value = today.toISOString().slice(0,10);
   els.planEnd.value = end.toISOString().slice(0,10);
+  els.boardDate.value = today.toISOString().slice(0,10);
+  renderTrucks();
   await refreshCarriersDatalist();
   await loadOrders();
 })();

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,8 @@
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
 h1,h2,h3{margin:0 0 8px}
+h4{margin:18px 0 8px}
+.section-title{color:var(--muted);text-transform:uppercase;font-size:11px;letter-spacing:.08em}
 .small{font-size:12px}
 .muted{color:var(--muted)}
 .site-header{padding:18px;border-bottom:1px solid var(--line)}
@@ -15,19 +17,44 @@ h1,h2,h3{margin:0 0 8px}
 .content{display:flex;flex-direction:column;gap:16px}
 .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:14px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
 label{display:block;margin:8px 0;color:var(--muted)}
-input,select{width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0b1020;color:var(--text);outline:none}
-.btn{padding:9px 12px;border:1px solid var(--line);border-radius:10px;background:#0b1020;color:var(--text);cursor:pointer;font-weight:600}
+input,select,textarea{width:100%;padding:9px 10px;border:1px solid var(--line);border-radius:10px;background:#0b1020;color:var(--text);outline:none;font:inherit}
+textarea{resize:vertical;min-height:70px}
+.btn{padding:9px 12px;border:1px solid var(--line);border-radius:10px;background:#0b1020;color:var(--text);cursor:pointer;font-weight:600;transition:transform .15s ease,box-shadow .15s ease}
+.btn:hover{transform:translateY(-1px);box-shadow:0 6px 16px rgba(0,0,0,.35)}
 .btn.primary{background:var(--accent);color:#06210f;border-color:#1e8c49}
 .btn.ghost{background:#0b1020}
+.btn.small{padding:5px 8px;font-size:12px}
 .status{font-size:12px;color:var(--muted);margin-top:6px}
 .grid2{display:grid;gap:10px;grid-template-columns:1fr 1fr}
 @media(max-width:760px){.grid2{grid-template-columns:1fr}}
 .grid3{display:grid;gap:10px;grid-template-columns:1fr 1fr 1fr}
 @media(max-width:900px){.grid3{grid-template-columns:1fr 1fr}}
+.grid4{display:grid;gap:10px;grid-template-columns:repeat(4,1fr)}
+@media(max-width:1100px){.grid4{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:640px){.grid4{grid-template-columns:1fr}}
 .table-wrap{overflow:auto;border:1px dashed var(--line);border-radius:12px}
 table{width:100%;border-collapse:collapse}
-th,td{padding:8px;border-bottom:1px solid var(--line);text-align:left}
-.bar{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
+th,td{padding:8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+.bar{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;gap:12px}
 dialog{border:none;padding:0;background:transparent}
 dialog::backdrop{background:rgba(0,0,0,.6)}
 .menu{display:flex;justify-content:flex-end;gap:10px;margin-top:10px}
+
+.truck-list{list-style:none;padding:0;margin:16px 0 0;display:flex;flex-direction:column;gap:10px}
+.truck-list li{padding:12px;border:1px dashed var(--line);border-radius:12px;background:rgba(255,255,255,.02);display:flex;flex-direction:column;gap:6px}
+.truck-list li header{display:flex;justify-content:space-between;align-items:center;gap:10px}
+.truck-meta{font-size:12px;color:var(--muted)}
+.board-controls label{margin-top:0}
+.board-actions{display:flex;align-items:center;gap:16px;margin-top:12px;flex-wrap:wrap}
+.board-grid{margin-top:18px;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px}
+.truck-card{border:1px solid var(--line);border-radius:14px;padding:12px;background:rgba(255,255,255,.02);display:flex;flex-direction:column;gap:12px}
+.truck-card header{display:flex;justify-content:space-between;align-items:center}
+.assignment{padding:10px;border-radius:10px;background:#111b33;border:1px solid rgba(255,255,255,.05);display:flex;flex-direction:column;gap:6px}
+.assignment strong{font-size:13px}
+.badge{display:inline-flex;align-items:center;gap:6px;padding:3px 8px;border-radius:999px;background:rgba(34,197,94,.15);color:var(--accent);font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.tag{display:inline-block;padding:2px 6px;border-radius:6px;background:rgba(148,163,184,.2);color:var(--text);font-size:11px;margin-right:4px}
+.empty-hint{color:var(--muted);font-size:13px}
+
+@media(max-width:600px){
+  .board-actions{flex-direction:column;align-items:flex-start}
+}


### PR DESCRIPTION
## Summary
- breid het invoerformulier uit met velden voor laad- en losadressen, contactinformatie en ladingspecificaties
- voeg lokaal vrachtwagenbeheer en een planbord toe om transporten aan voertuigen en tijdsloten te koppelen
- style de interface opnieuw voor de nieuwe secties en het interactieve planoverzicht

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dcefae3330832b8c126bb5a4809bff