### PR TITLE
Improve planner validation and feedback

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,8 @@
   --color-text: #2B2B2B;
   --color-muted: #6F6F6F;
   --color-border: #E0E0E0;
+  --color-error: #C62828;
+  --color-success: #2E7D32;
   --shadow-sm: 0 4px 12px rgba(43, 43, 43, 0.08);
   --radius-sm: 8px;
   --radius-md: 10px;
@@ -235,6 +237,18 @@ textarea {
   font-size: 12px;
   color: var(--color-muted);
   margin-top: 6px;
+}
+
+.status.status-error {
+  color: var(--color-error);
+}
+
+.status.status-success {
+  color: var(--color-success);
+}
+
+.error-text {
+  color: var(--color-error);
 }
 
 .grid2 {


### PR DESCRIPTION
## Summary
- add reusable status helper with styled error/success feedback and loading placeholders for the ordertabel
- validate invoer voor order-, carrier- en wagenbeheer en zorg dat het planbord met string-ID's overweg kan
- maak de auto-planner robuuster met foutafhandeling tijdens voorstellen en opslaan

## Testing
- node --check js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dcf7855e6c832bab14f8281415894e