### PR TITLE
Add Supabase-backed user management and login

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -6,17 +6,21 @@
   <title>Transportplanner — Nieuwe aanvraag</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Leg nieuwe transportaanvragen vast inclusief alle details.</div>
-    <nav class="main-nav">
-      <a href="index.html">Start</a>
-      <a href="aanvraag.html" class="active">Nieuwe aanvraag</a>
-      <a href="orders.html">Orders</a>
-      <a href="planning.html">Planning</a>
-      <a href="vloot.html">Vloot &amp; carriers</a>
-    </nav>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html" class="active">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
   </header>
 
   <main class="page">
@@ -134,6 +138,7 @@
 
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,17 +6,21 @@
   <title>Transportplanner — Start</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Complete workflow voor transportaanvragen, vrachtwagenbeheer en planning.</div>
-    <nav class="main-nav">
-      <a href="index.html" class="active">Start</a>
-      <a href="aanvraag.html">Nieuwe aanvraag</a>
-      <a href="orders.html">Orders</a>
-      <a href="planning.html">Planning</a>
-      <a href="vloot.html">Vloot &amp; carriers</a>
-    </nav>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html" class="active">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
   </header>
 
   <main class="home-page">
@@ -47,5 +51,9 @@
       </a>
     </section>
   </main>
+
+  <script src="js/config.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
 </body>
 </html>

--- a/js/api.js
+++ b/js/api.js
@@ -67,3 +67,25 @@ const Carriers = {
   create: (c) => sbInsert("carriers", [c]).then(r => r[0]),
   update: (id, patch) => sbUpdate("carriers", `id=eq.${id}`, patch),
 };
+
+const Users = {
+  list: () => sbSelect(
+    "app_users",
+    "?select=id,full_name,email,role,is_active,created_at&order=full_name.asc"
+  ),
+  create: (user) => sbInsert("app_users", [user]).then(r => r[0]),
+  update: (id, patch) => sbUpdate("app_users", `id=eq.${id}`, patch).then(r => r[0]),
+  remove: (id) => sbDelete("app_users", `id=eq.${id}`),
+  setPassword: (id, passwordHash) =>
+    sbUpdate("app_users", `id=eq.${id}`, { password_hash: passwordHash }).then(r => r[0]),
+  authenticate: async (email, passwordHash) => {
+    const query = `?select=id,full_name,email,role,is_active&email=eq.${encodeURIComponent(email)}&password_hash=eq.${encodeURIComponent(passwordHash)}`;
+    const result = await sbSelect("app_users", query);
+    return result[0] || null;
+  }
+};
+
+window.Orders = Orders;
+window.Lines = Lines;
+window.Carriers = Carriers;
+window.Users = Users;

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,222 @@
+(function () {
+  const STORAGE_KEY = "transportplanner_user_v1";
+  const listeners = new Set();
+  let cachedUser = null;
+  let domReady = false;
+
+  const storageAvailable = (() => {
+    try {
+      const testKey = "__auth_test__";
+      window.localStorage.setItem(testKey, testKey);
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (err) {
+      console.warn("Kan localStorage niet gebruiken voor sessies", err);
+      return false;
+    }
+  })();
+
+  function readStoredUser() {
+    if (!storageAvailable) return null;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (err) {
+      console.warn("Kan gebruikerssessie niet lezen", err);
+      return null;
+    }
+  }
+
+  function writeStoredUser(user) {
+    if (!storageAvailable) return;
+    try {
+      if (user) {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (err) {
+      console.warn("Kan gebruikerssessie niet opslaan", err);
+    }
+  }
+
+  function getUser() {
+    if (cachedUser) return cachedUser;
+    cachedUser = readStoredUser();
+    return cachedUser;
+  }
+
+  function setUser(user) {
+    cachedUser = user || null;
+    writeStoredUser(cachedUser);
+    notify();
+  }
+
+  async function hashPassword(password) {
+    if (!password) return "";
+    if (window.crypto?.subtle) {
+      const data = new TextEncoder().encode(password);
+      const hash = await window.crypto.subtle.digest("SHA-256", data);
+      const hashArray = Array.from(new Uint8Array(hash));
+      return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+    }
+    // Fallback (niet cryptografisch veilig, maar voorkomt blokkeren op oudere browsers)
+    let hash = 0;
+    for (let i = 0; i < password.length; i += 1) {
+      hash = (hash << 5) - hash + password.charCodeAt(i);
+      hash |= 0;
+    }
+    return hash.toString(16);
+  }
+
+  async function login(email, password) {
+    const cleanedEmail = (email || "").trim().toLowerCase();
+    const passwordHash = await hashPassword(password || "");
+    if (!cleanedEmail || !passwordHash) {
+      throw new Error("Vul een e-mailadres en wachtwoord in.");
+    }
+    if (!window.Users || typeof window.Users.authenticate !== "function") {
+      throw new Error("Users API is niet beschikbaar");
+    }
+    const user = await window.Users.authenticate(cleanedEmail, passwordHash);
+    if (!user) {
+      throw new Error("Onjuiste inloggegevens");
+    }
+    if (!user.is_active) {
+      throw new Error("Dit account is gedeactiveerd");
+    }
+    const session = {
+      id: user.id,
+      name: user.full_name,
+      email: user.email,
+      role: user.role,
+    };
+    setUser(session);
+    return session;
+  }
+
+  function logout() {
+    setUser(null);
+  }
+
+  function updateAuthArea() {
+    const area = document.getElementById("authArea");
+    if (!area) return;
+    const user = getUser();
+    if (!user) {
+      area.innerHTML = '<a class="btn primary small" href="login.html">Inloggen</a>';
+      return;
+    }
+    area.innerHTML = `
+      <div class="auth-summary">
+        <span class="auth-user">${user.name}</span>
+        <span class="auth-role">${user.role}</span>
+      </div>
+      <button class="btn ghost small" id="btnLogout" type="button">Uitloggen</button>
+    `;
+    const btn = document.getElementById("btnLogout");
+    if (btn) {
+      btn.addEventListener("click", (evt) => {
+        evt.preventDefault();
+        logout();
+      });
+    }
+  }
+
+  function applyRoleVisibility() {
+    const user = getUser();
+    const visible = document.querySelectorAll("[data-role-visible]");
+    visible.forEach((el) => {
+      const roles = el.dataset.roleVisible
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean);
+      if (!user || !roles.includes(user.role)) {
+        el.classList.add("is-hidden-role");
+      } else {
+        el.classList.remove("is-hidden-role");
+      }
+    });
+  }
+
+  function isLoginPage() {
+    return window.location.pathname.endsWith("/login.html") || window.location.pathname.endsWith("login.html");
+  }
+
+  function enforceAccess() {
+    const body = document.body;
+    if (!body) return;
+    const requireAuth = body.dataset.requireAuth === "true";
+    const requireRoleAttr = body.dataset.requireRole;
+    const user = getUser();
+
+    if (requireAuth && !user) {
+      if (!isLoginPage()) {
+        window.location.href = "login.html";
+      }
+      return;
+    }
+
+    if (requireRoleAttr) {
+      const requiredRoles = requireRoleAttr
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean);
+      if (!user || (requiredRoles.length && !requiredRoles.includes(user.role))) {
+        window.location.href = "index.html";
+        return;
+      }
+    }
+
+    if (isLoginPage() && user) {
+      window.location.href = "index.html";
+    }
+  }
+
+  function notify() {
+    if (domReady) {
+      updateAuthArea();
+      applyRoleVisibility();
+      enforceAccess();
+    }
+    const currentUser = getUser();
+    listeners.forEach((listener) => {
+      try {
+        listener(currentUser);
+      } catch (err) {
+        console.error("Fout in auth listener", err);
+      }
+    });
+  }
+
+  function onChange(handler) {
+    if (typeof handler === "function") {
+      listeners.add(handler);
+      return () => listeners.delete(handler);
+    }
+    return () => {};
+  }
+
+  window.Auth = {
+    getUser,
+    login,
+    logout,
+    hashPassword,
+    onChange,
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    domReady = true;
+    if (!cachedUser) {
+      cachedUser = readStoredUser();
+    }
+    notify();
+  });
+
+  window.addEventListener("storage", (event) => {
+    if (event.key === STORAGE_KEY) {
+      cachedUser = readStoredUser();
+      notify();
+    }
+  });
+})();

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,45 @@
+(function () {
+  function setStatus(message, variant = "default") {
+    const el = document.getElementById("loginStatus");
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove("status-error", "status-success");
+    if (variant === "error") {
+      el.classList.add("status-error");
+    } else if (variant === "success") {
+      el.classList.add("status-success");
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("loginForm");
+    const email = document.getElementById("loginEmail");
+    const password = document.getElementById("loginPassword");
+    const button = document.getElementById("btnLogin");
+
+    if (!form || !window.Auth) return;
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!email || !password) return;
+      const mailValue = email.value;
+      const passValue = password.value;
+
+      setStatus("Controleren…");
+      button.disabled = true;
+
+      try {
+        await window.Auth.login(mailValue, passValue);
+        setStatus("Succesvol ingelogd, even geduld…", "success");
+        window.setTimeout(() => {
+          window.location.href = "index.html";
+        }, 400);
+      } catch (err) {
+        console.error(err);
+        setStatus(err.message || "Inloggen mislukt", "error");
+      } finally {
+        button.disabled = false;
+      }
+    });
+  });
+})();

--- a/js/users.js
+++ b/js/users.js
@@ -1,0 +1,180 @@
+(function () {
+  const els = {
+    form: document.getElementById("userForm"),
+    name: document.getElementById("uName"),
+    email: document.getElementById("uEmail"),
+    role: document.getElementById("uRole"),
+    password: document.getElementById("uPassword"),
+    active: document.getElementById("uActive"),
+    status: document.getElementById("userStatus"),
+    tableBody: document.querySelector("#userTable tbody"),
+    reload: document.getElementById("btnReloadUsers"),
+  };
+
+  let USER_CACHE = [];
+
+  function setStatus(message, variant = "default") {
+    if (!els.status) return;
+    els.status.textContent = message;
+    els.status.classList.remove("status-error", "status-success");
+    if (variant === "error") {
+      els.status.classList.add("status-error");
+    } else if (variant === "success") {
+      els.status.classList.add("status-success");
+    }
+  }
+
+  function formatDate(value) {
+    if (!value) return "-";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString("nl-NL", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  }
+
+  function renderUsers(users) {
+    if (!els.tableBody) return;
+    if (!users.length) {
+      els.tableBody.innerHTML = '<tr><td colspan="6" class="muted">Geen gebruikers gevonden.</td></tr>';
+      return;
+    }
+
+    const rows = users
+      .map((user) => {
+        const toggleLabel = user.is_active ? "Deactiveer" : "Activeer";
+        const statusLabel = user.is_active ? "Actief" : "Gedeactiveerd";
+        return `
+          <tr data-id="${user.id}">
+            <td>${user.full_name}</td>
+            <td>${user.email}</td>
+            <td>${user.role}</td>
+            <td>${statusLabel}</td>
+            <td>${formatDate(user.created_at)}</td>
+            <td class="actions">
+              <button class="btn ghost small" data-action="toggle">${toggleLabel}</button>
+              <button class="btn small" data-action="reset">Reset wachtwoord</button>
+            </td>
+          </tr>
+        `;
+      })
+      .join("");
+
+    els.tableBody.innerHTML = rows;
+  }
+
+  async function loadUsers(showMessage = false) {
+    if (!window.Users) {
+      setStatus("Users API niet beschikbaar", "error");
+      return;
+    }
+    try {
+      if (showMessage) setStatus("Gebruikers laden…");
+      USER_CACHE = await window.Users.list();
+      renderUsers(USER_CACHE);
+      if (showMessage) setStatus("Gebruikers bijgewerkt", "success");
+    } catch (err) {
+      console.error(err);
+      setStatus("Kan gebruikers niet laden", "error");
+    }
+  }
+
+  async function handleCreate(event) {
+    event.preventDefault();
+    if (!els.form || !window.Users || !window.Auth) return;
+    const name = (els.name?.value || "").trim();
+    const email = (els.email?.value || "").trim().toLowerCase();
+    const role = els.role?.value || "werknemer";
+    const password = els.password?.value || "";
+    const active = !!els.active?.checked;
+
+    if (!name || !email || !password) {
+      setStatus("Vul alle verplichte velden in", "error");
+      return;
+    }
+
+    try {
+      setStatus("Gebruiker wordt opgeslagen…");
+      const passwordHash = await window.Auth.hashPassword(password);
+      const payload = {
+        full_name: name,
+        email,
+        role,
+        password_hash: passwordHash,
+        is_active: active,
+      };
+      await window.Users.create(payload);
+      setStatus("Gebruiker toegevoegd", "success");
+      els.form.reset();
+      if (els.active) els.active.checked = true;
+      await loadUsers(false);
+    } catch (err) {
+      console.error(err);
+      setStatus("Opslaan mislukt: " + (err.message || "onbekende fout"), "error");
+    }
+  }
+
+  async function toggleActive(id) {
+    if (!window.Users) return;
+    const user = USER_CACHE.find((u) => u.id === id);
+    if (!user) return;
+    try {
+      setStatus("Status wijzigen…");
+      await window.Users.update(id, { is_active: !user.is_active });
+      setStatus("Status bijgewerkt", "success");
+      await loadUsers(false);
+    } catch (err) {
+      console.error(err);
+      setStatus("Kon status niet wijzigen", "error");
+    }
+  }
+
+  async function resetPassword(id) {
+    if (!window.Users || !window.Auth) return;
+    const user = USER_CACHE.find((u) => u.id === id);
+    if (!user) return;
+    const newPassword = window.prompt(`Nieuw wachtwoord voor ${user.full_name}:`);
+    if (!newPassword) return;
+    try {
+      setStatus("Wachtwoord wordt bijgewerkt…");
+      const hash = await window.Auth.hashPassword(newPassword);
+      await window.Users.setPassword(id, hash);
+      setStatus("Wachtwoord opnieuw ingesteld", "success");
+    } catch (err) {
+      console.error(err);
+      setStatus("Kon wachtwoord niet bijwerken", "error");
+    }
+  }
+
+  function handleAction(event) {
+    const button = event.target.closest("button[data-action]");
+    if (!button) return;
+    event.preventDefault();
+    const row = button.closest("tr[data-id]");
+    if (!row) return;
+    const id = row.dataset.id;
+    const action = button.dataset.action;
+    if (action === "toggle") {
+      toggleActive(id);
+    } else if (action === "reset") {
+      resetPassword(id);
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    if (els.form) {
+      els.form.addEventListener("submit", handleCreate);
+    }
+    if (els.reload) {
+      els.reload.addEventListener("click", (event) => {
+        event.preventDefault();
+        loadUsers(true);
+      });
+    }
+    if (els.tableBody) {
+      els.tableBody.addEventListener("click", handleAction);
+    }
+    loadUsers(true);
+  });
+})();

--- a/login.html
+++ b/login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transportplanner — Inloggen</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <h1>Transportplanner</h1>
+    <div class="sub">Log in om toegang te krijgen tot de modules.</div>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
+  </header>
+
+  <main class="page login-page">
+    <section class="card narrow">
+      <h2>Inloggen</h2>
+      <p class="muted small">Gebruik het e-mailadres en wachtwoord dat is toegewezen in Supabase.</p>
+      <form id="loginForm" class="stack">
+        <label>E-mailadres
+          <input type="email" id="loginEmail" required autocomplete="email" />
+        </label>
+        <label>Wachtwoord
+          <input type="password" id="loginPassword" required autocomplete="current-password" />
+        </label>
+        <button class="btn primary" type="submit" id="btnLogin">Inloggen</button>
+      </form>
+      <div id="loginStatus" class="status" role="status"></div>
+    </section>
+  </main>
+
+  <script src="js/config.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/login.js"></script>
+</body>
+</html>

--- a/orders.html
+++ b/orders.html
@@ -6,17 +6,21 @@
   <title>Transportplanner — Orders</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Bekijk en bewerk bestaande transporten.</div>
-    <nav class="main-nav">
-      <a href="index.html">Start</a>
-      <a href="aanvraag.html">Nieuwe aanvraag</a>
-      <a href="orders.html" class="active">Orders</a>
-      <a href="planning.html">Planning</a>
-      <a href="vloot.html">Vloot &amp; carriers</a>
-    </nav>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html" class="active">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
   </header>
 
   <main class="wrap">
@@ -116,6 +120,7 @@
 
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/planning.html
+++ b/planning.html
@@ -6,17 +6,21 @@
   <title>Transportplanner — Planning</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Plan transporten in op basis van capaciteit en beschikbaarheid.</div>
-    <nav class="main-nav">
-      <a href="index.html">Start</a>
-      <a href="aanvraag.html">Nieuwe aanvraag</a>
-      <a href="orders.html">Orders</a>
-      <a href="planning.html" class="active">Planning</a>
-      <a href="vloot.html">Vloot &amp; carriers</a>
-    </nav>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html" class="active">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
   </header>
 
   <main class="wrap">
@@ -77,6 +81,7 @@
 
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -73,11 +73,19 @@ h4 {
   color: var(--color-muted);
 }
 
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+}
+
 .main-nav {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  margin-top: 16px;
 }
 
 .main-nav a {
@@ -100,6 +108,35 @@ h4 {
   background: var(--color-primary);
   color: #ffffff;
   border-color: var(--color-primary);
+}
+
+.auth-area {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.auth-area .auth-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: right;
+}
+
+.auth-area .auth-user {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.auth-area .auth-role {
+  text-transform: capitalize;
+  color: var(--color-muted);
+}
+
+.auth-area .btn {
+  margin-left: 4px;
 }
 
 .wrap {
@@ -167,6 +204,55 @@ h4 {
   border-radius: var(--radius-md);
   padding: 18px;
   box-shadow: var(--shadow-sm);
+}
+
+.card.narrow {
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.login-page {
+  display: flex;
+  justify-content: center;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--color-muted);
+}
+
+.checkbox input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.is-hidden-role {
+  display: none !important;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actions .btn {
+  flex: 0 0 auto;
 }
 
 label {
@@ -261,6 +347,11 @@ textarea {
   .grid2 {
     grid-template-columns: 1fr;
   }
+}
+
+.grid2 .checkbox,
+.grid2 .form-actions {
+  grid-column: 1 / -1;
 }
 
 .grid3 {

--- a/supabase_users.sql
+++ b/supabase_users.sql
@@ -1,0 +1,51 @@
+-- Maak benodigde extensies voor UUID en case-insensitieve e-mailvergelijking
+create extension if not exists pgcrypto;
+create extension if not exists citext;
+
+-- Tabel met applicatiegebruikers voor de transportplanner
+create table if not exists public.app_users (
+  id uuid primary key default gen_random_uuid(),
+  full_name text not null,
+  email citext not null unique,
+  role text not null check (role in ('admin', 'planner', 'werknemer')),
+  password_hash text not null,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+comment on table public.app_users is 'Authenticatiegebruikers voor de transportplanner webapplicatie.';
+
+-- Schakel Row Level Security in en maak eenvoudige policies voor de demo.
+-- Let op: in productie moeten policies worden aangescherpt zodat alleen geautoriseerde
+-- service clients deze tabel kunnen wijzigen.
+alter table public.app_users enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'app_users'
+      and policyname = 'allow anon read users'
+  ) then
+    create policy "allow anon read users"
+      on public.app_users
+      for select
+      using (true);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'app_users'
+      and policyname = 'allow anon modify users'
+  ) then
+    create policy "allow anon modify users"
+      on public.app_users
+      for all
+      using (true)
+      with check (true);
+  end if;
+end $$;

--- a/users.html
+++ b/users.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transportplanner — Gebruikersbeheer</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body data-require-auth="true" data-require-role="admin">
+  <header class="site-header">
+    <h1>Gebruikersbeheer</h1>
+    <div class="sub">Beheer inloggegevens en rollen voor de transportplanner.</div>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="users.html" class="active nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
+  </header>
+
+  <main class="page">
+    <section class="card">
+      <h2>Nieuwe gebruiker toevoegen</h2>
+      <form id="userForm" class="grid2">
+        <label>Naam
+          <input id="uName" placeholder="Bijv. Jan Planner" required />
+        </label>
+        <label>E-mailadres
+          <input id="uEmail" type="email" placeholder="planner@bedrijf.nl" required />
+        </label>
+        <label>Rol
+          <select id="uRole" required>
+            <option value="admin">Admin</option>
+            <option value="planner">Planner</option>
+            <option value="werknemer">Werknemer</option>
+          </select>
+        </label>
+        <label>Tijdelijk wachtwoord
+          <input id="uPassword" type="password" required minlength="6" placeholder="Minimaal 6 tekens" />
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" id="uActive" checked /> Actief account
+        </label>
+        <div class="form-actions">
+          <button type="submit" class="btn primary">Gebruiker opslaan</button>
+        </div>
+      </form>
+      <div id="userStatus" class="status" role="status"></div>
+    </section>
+
+    <section class="card">
+      <div class="bar">
+        <h2>Bestaande gebruikers</h2>
+        <button class="btn ghost small" id="btnReloadUsers">Vernieuwen</button>
+      </div>
+      <div class="table-wrap">
+        <table id="userTable">
+          <thead>
+            <tr>
+              <th>Naam</th>
+              <th>E-mail</th>
+              <th>Rol</th>
+              <th>Status</th>
+              <th>Aangemaakt</th>
+              <th>Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td colspan="6" class="muted">Nog geen gebruikers geladen…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script src="js/config.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/users.js"></script>
+</body>
+</html>

--- a/vloot.html
+++ b/vloot.html
@@ -6,17 +6,21 @@
   <title>Transportplanner — Vloot &amp; carriers</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
+<body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Beheer lokale vrachtwagens en registreer externe carriers.</div>
-    <nav class="main-nav">
-      <a href="index.html">Start</a>
-      <a href="aanvraag.html">Nieuwe aanvraag</a>
-      <a href="orders.html">Orders</a>
-      <a href="planning.html">Planning</a>
-      <a href="vloot.html" class="active">Vloot &amp; carriers</a>
-    </nav>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html">Planning</a>
+        <a href="vloot.html" class="active">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
   </header>
 
   <main class="page">
@@ -67,6 +71,7 @@
 
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require login across application pages through a reusable browser auth helper backed by Supabase
- add a dedicated login view and admin-only user management console to create, toggle, and reset users
- refresh shared navigation and styling to show the current session and document the Supabase `app_users` table setup

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dcfca21420832baf7544878630b43e