### PR TITLE
Add guard for missing Supabase configuration

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,3 +1,11 @@
+if (
+  !window.APP_CONFIG ||
+  !window.APP_CONFIG.SUPABASE_URL ||
+  !window.APP_CONFIG.SUPABASE_ANON_KEY
+) {
+  throw new Error("Supabase configuratie ontbreekt in window.APP_CONFIG");
+}
+
 const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.APP_CONFIG;
 
 const SB_HEADERS = {


### PR DESCRIPTION
## Summary
- add a runtime guard to ensure Supabase configuration is present before initializing API helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd097ec28c832ba8032581bec8ad68