### PR TITLE
Restrict order editing to owners

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -58,7 +58,9 @@ const Orders = {
     const params = [];
     if (filters.region) params.push(`region=eq.${encodeURIComponent(filters.region)}`);
     if (filters.status) params.push(`status=eq.${encodeURIComponent(filters.status)}`);
-    const qs = params.length ? `?${params.join("&")}&order=due_date.asc` : `?order=due_date.asc`;
+    if (filters.createdBy) params.push(`created_by=eq.${encodeURIComponent(filters.createdBy)}`);
+    params.push("order=due_date.asc");
+    const qs = `?${params.join("&")}`;
     return sbSelect("transport_orders", qs);
   },
   create: (o) => sbInsert("transport_orders", [o]).then(r => r[0]),


### PR DESCRIPTION
## Summary
- include creator metadata when creating orders and pass created_by filters through the API
- filter employee order lists client-side when necessary and persist owner info for UI behaviour
- block workers from opening or saving edits on orders owned by other users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd107e7ecc832ba10c7008d6d8f6ce