### PR TITLE
Allow deleting transport orders with role-based checks

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -63,6 +63,7 @@ const Orders = {
   },
   create: (o) => sbInsert("transport_orders", [o]).then(r => r[0]),
   update: (id, patch) => sbUpdate("transport_orders", `id=eq.${id}`, patch),
+  delete: (id) => sbDelete("transport_orders", `id=eq.${id}`),
 };
 
 const Lines = {

--- a/js/app.js
+++ b/js/app.js
@@ -47,6 +47,7 @@ const els = {
   ePlanned: document.getElementById("ePlanned"),
   eSlot: document.getElementById("eSlot"),
   btnSaveEdit: document.getElementById("btnSaveEdit"),
+  btnDeleteOrder: document.getElementById("btnDeleteOrder"),
   carrierList: document.getElementById("carrierList"),
   truckName: document.getElementById("truckName"),
   truckPlate: document.getElementById("truckPlate"),
@@ -113,6 +114,13 @@ let ORDERS_CACHE = [];
 let PLAN_SUGGESTIONS = [];
 let TRUCKS = [];
 let PLAN_BOARD = {};
+
+function getCurrentUser() {
+  if (window.Auth && typeof window.Auth.getUser === "function") {
+    return window.Auth.getUser();
+  }
+  return null;
+}
 
 function hydrateLocalState() {
   TRUCKS = storageGet(STORAGE_KEYS.trucks, []);
@@ -316,6 +324,90 @@ async function saveEdit(){
   await Orders.update(id, patch);
   els.dlg.close();
   await loadOrders();
+}
+
+function getOrderById(id) {
+  return ORDERS_CACHE.find((o) => String(o.id) === String(id));
+}
+
+function isOrderOwnedByUser(order, user) {
+  if (!order || !user) return false;
+  const userId = user.id ? String(user.id) : null;
+  const userEmail = user.email ? String(user.email).toLowerCase() : null;
+  const idFields = [
+    "created_by_user_id",
+    "created_by_id",
+    "created_by",
+    "requested_by_user_id",
+    "requested_by_id",
+    "requester_id",
+    "user_id",
+    "owner_id",
+  ];
+  for (const field of idFields) {
+    if (order[field] && userId && String(order[field]) === userId) {
+      return true;
+    }
+  }
+  const emailFields = [
+    "created_by_email",
+    "requested_by_email",
+    "requester_email",
+    "customer_email",
+    "created_by",
+    "requested_by",
+  ];
+  for (const field of emailFields) {
+    const value = order[field];
+    if (value && userEmail && String(value).toLowerCase() === userEmail) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function canDeleteOrder(order, user) {
+  if (!user) return false;
+  if (user.role === "admin" || user.role === "planner") {
+    return true;
+  }
+  if (user.role === "werknemer") {
+    return isOrderOwnedByUser(order, user);
+  }
+  return false;
+}
+
+async function handleDeleteOrder(event) {
+  event.preventDefault();
+  if (!els.eId) return;
+  const id = els.eId.value;
+  if (!id) return;
+  const user = getCurrentUser();
+  if (!user) {
+    window.alert("Je bent niet ingelogd.");
+    return;
+  }
+  const order = getOrderById(id);
+  if (!canDeleteOrder(order, user)) {
+    window.alert("Je hebt geen toestemming om deze order te verwijderen.");
+    return;
+  }
+  const descriptionParts = [];
+  if (order?.customer_name) descriptionParts.push(order.customer_name);
+  if (order?.due_date) descriptionParts.push(order.due_date);
+  const description = descriptionParts.length ? descriptionParts.join(" – ") : `order ${id}`;
+  const confirmed = window.confirm(`Weet je zeker dat je ${description} wilt verwijderen? Dit kan niet ongedaan worden gemaakt.`);
+  if (!confirmed) return;
+  try {
+    await Orders.delete(id);
+    if (els.dlg) {
+      els.dlg.close();
+    }
+    await loadOrders();
+  } catch (err) {
+    console.error("Kan order niet verwijderen", err);
+    window.alert("Verwijderen is mislukt. Probeer het opnieuw.");
+  }
 }
 
 function readNumber(value) {
@@ -881,6 +973,7 @@ function bind(){
   bindClick(els.btnAddCarrier, addCarrier);
   bindClick(els.btnSuggestPlan, suggestPlan);
   bindClick(els.btnApplyPlan, applyPlan);
+  bindClick(els.btnDeleteOrder, handleDeleteOrder);
   if (els.btnSaveEdit) {
     els.btnSaveEdit.addEventListener("click", (e)=>{ e.preventDefault(); saveEdit(); });
   }

--- a/orders.html
+++ b/orders.html
@@ -113,6 +113,7 @@
       </div>
       <menu class="menu">
         <button value="cancel" class="btn ghost">Annuleren</button>
+        <button id="btnDeleteOrder" type="button" class="btn ghost" data-role-visible="admin,planner,werknemer">Verwijderen</button>
         <button id="btnSaveEdit" value="default" class="btn primary">Opslaan</button>
       </menu>
     </form>


### PR DESCRIPTION
## Summary
- add an Orders.delete helper that removes transport orders via the Supabase REST API
- show a delete action inside the order edit dialog for permitted roles
- implement a delete handler that enforces role/ownership checks, confirms the action, and refreshes the table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd10831f34832ba17a4ac1d335733f