### PR TITLE
Harden order ownership handling

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -54,11 +54,16 @@ async function sbDelete(table, match) {
 
 // Domein-functies
 const Orders = {
-  list: (filters={}) => {
+  list: (filters = {}) => {
     const params = [];
     if (filters.region) params.push(`region=eq.${encodeURIComponent(filters.region)}`);
     if (filters.status) params.push(`status=eq.${encodeURIComponent(filters.status)}`);
-    const qs = params.length ? `?${params.join("&")}&order=due_date.asc` : `?order=due_date.asc`;
+    const createdBy = filters.createdBy;
+    if (createdBy !== undefined && createdBy !== null && String(createdBy).length) {
+      params.push(`created_by=eq.${encodeURIComponent(createdBy)}`);
+    }
+    params.push("order=due_date.asc");
+    const qs = `?${params.join("&")}`;
     return sbSelect("transport_orders", qs);
   },
   create: (o) => sbInsert("transport_orders", [o]).then(r => r[0]),

--- a/js/app.js
+++ b/js/app.js
@@ -113,6 +113,40 @@ let ORDERS_CACHE = [];
 let PLAN_SUGGESTIONS = [];
 let TRUCKS = [];
 let PLAN_BOARD = {};
+const ORDER_OWNERS = new Map();
+
+function getCurrentUser() {
+  if (window.Auth && typeof window.Auth.getUser === "function") {
+    return window.Auth.getUser();
+  }
+  return null;
+}
+
+function rememberOrderOwners(rows) {
+  ORDER_OWNERS.clear();
+  if (!Array.isArray(rows)) return;
+  rows.forEach((row) => {
+    if (!row || row.id === undefined || row.id === null) return;
+    const key = String(row.id);
+    ORDER_OWNERS.set(key, {
+      id: row.created_by ?? null,
+      name: row.created_by_name ?? null,
+    });
+  });
+}
+
+function getOrderOwner(order) {
+  const id = typeof order === "object" ? order?.id : order;
+  if (id === undefined || id === null) return null;
+  return ORDER_OWNERS.get(String(id)) || null;
+}
+
+function canUserEditOrder(order, user = getCurrentUser()) {
+  if (!user || user.role !== "werknemer") return true;
+  const owner = getOrderOwner(order);
+  if (!owner || !owner.id) return true;
+  return String(owner.id) === String(user.id);
+}
 
 function hydrateLocalState() {
   TRUCKS = storageGet(STORAGE_KEYS.trucks, []);
@@ -239,17 +273,29 @@ async function refreshCarriersDatalist() {
 }
 
 async function loadOrders() {
-  const filters = {
+  const currentUser = getCurrentUser();
+  const listFilters = {
     region: els.filterRegion?.value || undefined,
     status: els.filterStatus?.value || undefined,
   };
+  let createdByFilter;
+  if (currentUser?.role === "werknemer" && currentUser.id !== undefined && currentUser.id !== null) {
+    createdByFilter = currentUser.id;
+    listFilters.createdBy = createdByFilter;
+  }
   if (els.ordersTable) {
     renderOrdersPlaceholder("Bezig met laden…");
   }
   try {
-    const rows = await Orders.list(filters);
-    ORDERS_CACHE = rows;
-    renderOrders(rows);
+    const rows = await Orders.list(listFilters);
+    const safeRows = Array.isArray(rows) ? rows : [];
+    rememberOrderOwners(safeRows);
+    let filteredRows = safeRows;
+    if (createdByFilter) {
+      filteredRows = safeRows.filter((row) => String(row?.created_by ?? "") === String(createdByFilter));
+    }
+    ORDERS_CACHE = filteredRows;
+    renderOrders(filteredRows);
     updatePlanBoardSelectors();
     syncPlanBoardFromOrders();
     renderPlanBoard();
@@ -270,6 +316,7 @@ function renderOrders(rows) {
     renderOrdersPlaceholder("Geen orders gevonden");
     return;
   }
+  const currentUser = getCurrentUser();
   for (const r of rows) {
     const details = parseOrderDetails(r);
     const tr = document.createElement("tr");
@@ -277,6 +324,9 @@ function renderOrders(rows) {
     if (details.instructions) tooltip.push(`Instructies: ${details.instructions}`);
     if (details.contact) tooltip.push(`Contact: ${details.contact}`);
     tr.title = tooltip.join("\n");
+    const ownerInfo = getOrderOwner(r);
+    if (ownerInfo?.id) tr.dataset.ownerId = ownerInfo.id;
+    if (ownerInfo?.name) tr.dataset.ownerName = ownerInfo.name;
     tr.innerHTML = `
       <td>${r.due_date ?? details.delivery?.date ?? "-"}</td>
       <td>${details.reference ?? "-"}</td>
@@ -288,13 +338,24 @@ function renderOrders(rows) {
       <td>${r.assigned_carrier ?? "-"}</td>
       <td>${formatPlanned(r)}</td>
     `;
-    tr.addEventListener("click", () => openEdit(r));
+    if (canUserEditOrder(r, currentUser)) {
+      tr.addEventListener("click", () => openEdit(r));
+    } else {
+      tr.classList.add("is-readonly-order");
+    }
     tbody.appendChild(tr);
   }
 }
 
 function openEdit(row){
   if (!els.dlg) return;
+  const user = getCurrentUser();
+  if (user?.role === "werknemer" && !canUserEditOrder(row, user)) {
+    const owner = getOrderOwner(row);
+    const ownerName = owner?.name || "een andere medewerker";
+    window.alert(`Je kunt dit transport niet bewerken. Het is aangemaakt door ${ownerName}.`);
+    return;
+  }
   els.eId.value = row.id;
   els.eStatus.value = row.status || "Nieuw";
   els.eCarrier.value = row.assigned_carrier || "";
@@ -306,6 +367,13 @@ function openEdit(row){
 async function saveEdit(){
   if (!els.eId) return;
   const id = els.eId.value;
+  const user = getCurrentUser();
+  if (user?.role === "werknemer" && !canUserEditOrder({ id }, user)) {
+    const owner = getOrderOwner(id);
+    const ownerName = owner?.name || "een andere medewerker";
+    window.alert(`Je kunt dit transport niet opslaan. Het is aangemaakt door ${ownerName}.`);
+    return;
+  }
   const patch = {
     status: els.eStatus.value,
     assigned_carrier: els.eCarrier.value || null,
@@ -369,6 +437,7 @@ function resetOrderForm(){
 
 async function createOrder(){
   if (!els.oCustomer || !els.oRegion) return;
+  const user = getCurrentUser();
   const customerName = els.oCustomer.value.trim();
   if (!customerName) {
     setStatus(els.createStatus, "Vul de klantnaam in.", "error");
@@ -386,6 +455,14 @@ async function createOrder(){
       notes: "JSON:" + JSON.stringify(details),
       status: "Nieuw",
     };
+    const userId = user?.id ?? user?.user_id ?? null;
+    if (userId !== null && userId !== undefined) {
+      order.created_by = userId;
+      const creatorName = user?.name ?? user?.full_name ?? user?.email ?? null;
+      if (creatorName) {
+        order.created_by_name = creatorName;
+      }
+    }
     const created = await Orders.create(order);
     if (els.lProduct.value.trim()) {
       await Lines.create({


### PR DESCRIPTION
## Summary
- guard the orders API filter handling so created_by filtering skips empty values
- make order owner tracking resilient to unexpected payloads while still blocking unauthorized edits
- capture creator metadata with broader fallbacks when creating new orders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd107e7ecc832ba10c7008d6d8f6ce