### PR TITLE
Restrict fleet management to admins

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html" class="active">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/create-user.html
+++ b/create-user.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>
@@ -53,7 +53,7 @@
         <h3>Planning</h3>
         <p>Gebruik de auto-planner en het planbord om ritten aan vrachtwagens toe te wijzen.</p>
       </a>
-      <a class="card nav-card" href="vloot.html">
+      <a class="card nav-card" href="vloot.html" data-role-visible="admin">
         <h3>Vloot &amp; carriers</h3>
         <p>Beheer vrachtwagens en voeg carriers met capaciteit toe voor de auto-planner.</p>
       </a>

--- a/login.html
+++ b/login.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/orders.html
+++ b/orders.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html" class="active">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/planning.html
+++ b/planning.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" class="active">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/users.html
+++ b/users.html
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="vloot.html">Vloot &amp; carriers</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="active nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>

--- a/vloot.html
+++ b/vloot.html
@@ -6,7 +6,7 @@
   <title>Transportplanner — Vloot &amp; carriers</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body data-require-auth="true">
+<body data-require-auth="true" data-require-role="admin">
   <header class="site-header">
     <h1>Transportplanner</h1>
     <div class="sub">Beheer lokale vrachtwagens en registreer externe carriers.</div>
@@ -16,7 +16,7 @@
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="vloot.html" class="active">Vloot &amp; carriers</a>
+        <a href="vloot.html" class="active" data-role-visible="admin">Vloot &amp; carriers</a>
         <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
       </nav>
       <div class="auth-area" id="authArea"></div>


### PR DESCRIPTION
## Summary
- hide the fleet & carriers navigation entry from non-admin users across the app
- require the fleet management page to be accessed by admins only
- update the dashboard card to appear only for admins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd17b73bbc832baa73a3f7c9418ea5