### PR TITLE
Add process comparison overview page

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html" class="active">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>

--- a/create-user.html
+++ b/create-user.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html">Planning</a>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" class="active">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>
@@ -49,6 +50,10 @@
       <a class="card nav-card" href="orders.html">
         <h3>Orders</h3>
         <p>Filter en bekijk bestaande transporten. Bewerk status, carrier en planning vanuit de tabel.</p>
+      </a>
+      <a class="card nav-card" href="processen.html">
+        <h3>Procesoverzicht</h3>
+        <p>Vergelijk de gewenste workflow met de huidige app en plan verdere uitbreidingen.</p>
       </a>
       <a class="card nav-card" href="planning.html" data-role-visible="planner,admin">
         <h3>Planning</h3>

--- a/js/processen.js
+++ b/js/processen.js
@@ -1,0 +1,320 @@
+(function () {
+  const STATUS_META = {
+    covered: { label: "Gedekt", className: "status-badge success" },
+    partial: { label: "Gedeeltelijk", className: "status-badge warning" },
+    missing: { label: "Ontbreekt", className: "status-badge danger" },
+  };
+
+  const PROCESS_DATA = [
+    {
+      id: "create-transport-order",
+      title: "Create Transport Order",
+      requirement:
+        "Aanmaken en wijzigen van transportopdrachten, inclusief doorbrenger en retouropdrachten in één flow, met zichtbaarheid in het planner-dashboard en e-mailnotificaties bij wijzigingen.",
+      appSupport:
+        "De module Nieuwe aanvraag voorziet in uitgebreide orderinvoer en de orders-tabel laat status, carrier en planning aanpassen. De planning- en routepagina visualiseren opdrachten. Er ontbreekt nog ondersteuning voor gecombineerde doorbreng-/retourstromen en automatische e-mailmeldingen.",
+      status: "partial",
+      improvements: [
+        "Ondersteuning voor doorbrenger en retouropdrachten binnen één orderflow toevoegen.",
+        "Automatische e-mailnotificaties bij aanmaak, wijziging en annulering configureren.",
+      ],
+    },
+    {
+      id: "create-transport-list",
+      title: "Create Transport List (Rittenlijst & CMR)",
+      requirement:
+        "Geautomatiseerde generatie van rittenlijsten en CMR-documenten als PDF en distributie naar vooraf ingestelde e-maillijsten.",
+      appSupport:
+        "De huidige app biedt nog geen documentgeneratie of e-maildistributie voor rittenlijsten en CMR's.",
+      status: "missing",
+      improvements: [
+        "PDF-export voor rittenlijsten en CMR-documenten ontwikkelen.",
+        "Distributielijstbeheer en automatische verzending van documenten toevoegen.",
+      ],
+    },
+    {
+      id: "quote-to-cash",
+      title: "Quote to Cash (Validatieproces Sales)",
+      requirement:
+        "Workflow voor offertes en orderbevestigingen vanuit Salesforce waarbij documenten beoordeeld, goedgekeurd en automatisch verstuurd of geüpload worden.",
+      appSupport:
+        "Er is geen koppeling met Salesforce of een validatieworkflow voor salesdocumenten in de huidige applicatie.",
+      status: "missing",
+      improvements: [
+        "Validatie- en goedkeuringsworkflow voor salesdocumenten integreren.",
+        "API-koppeling met Salesforce of uploadmechanisme voor documenten realiseren.",
+      ],
+    },
+    {
+      id: "validation-used",
+      title: "Validation Process Used",
+      requirement:
+        "Afzonderlijk validatieproces voor de afdeling Used, zichtbaar als apart proces in de inbox.",
+      appSupport:
+        "Er is nog geen specifieke inbox of workflow voor de afdeling Used aanwezig.",
+      status: "missing",
+      improvements: [
+        "Inrichting van een aparte Used-workflow met eigen inbox en taken toevoegen.",
+        "Configuratie van statusovergangen en notificaties per Used-proces definiëren.",
+      ],
+    },
+    {
+      id: "matching-order-confirmations",
+      title: "Matching Order Confirmations",
+      requirement:
+        "Automatisch matchen van orderbevestigingen met inkooporders, met automatische afsluiting bij match en verplichte actie inclusief reden bij no-match.",
+      appSupport:
+        "Ordermatching gebeurt nu niet automatisch; medewerkers passen handmatig statussen aan in de orders-tabel zonder verplichte afsluitreden.",
+      status: "missing",
+      improvements: [
+        "Automatische matching tussen binnenkomende orderbevestigingen en inkooporders opzetten.",
+        "Dialoog voor verplichte afsluitreden bij no-match toevoegen.",
+      ],
+    },
+    {
+      id: "manage-delivery-dates",
+      title: "Manage Delivery Dates (Update leverweek)",
+      requirement:
+        "Wekelijks proces dat afwijkingen in leverweken signaleert, klanten een gebundelde update stuurt en de Opportunity Owner een keuze geeft om zelf of automatisch te communiceren.",
+      appSupport:
+        "De orderspagina toont leverdatums, maar er is geen geautomatiseerde weekcontrole of e-mailworkflow naar klanten en Opportunity Owners.",
+      status: "missing",
+      improvements: [
+        "Signalering van leverweekafwijkingen en dashboards voor Opportunity Owners implementeren.",
+        "Automatische bundelmail naar klanten met gewijzigde leveringen realiseren.",
+      ],
+    },
+    {
+      id: "supporting-processes",
+      title: "Overige ondersteunende processen",
+      requirement:
+        "Data Save, Customer Request, Manage Accounts, Manage Instructions, Service Notification en Overview Service Requests vanuit het serviceportaal.",
+      appSupport:
+        "Gebruikersbeheer is aanwezig via de pagina Gebruikers, maar overige serviceportaalprocessen en notificaties ontbreken nog.",
+      status: "partial",
+      improvements: [
+        "Integratie met serviceportaal voor klantaanvragen en servicemeldingen bouwen.",
+        "Beheer van instructies en taken voor serviceplanners toevoegen.",
+        "Opslag van dashboardwijzigingen synchroniseren tussen serviceportaal en planner.",
+      ],
+    },
+  ];
+
+  const CORE_DATA = [
+    {
+      id: "core-transport-orders",
+      title: "Transportopdrachten",
+      requirement:
+        "Invoer en wijziging van transportopdrachten met minimale dubbele registratie.",
+      appSupport:
+        "De app ondersteunt aanmaken en bijwerken via Nieuwe aanvraag en Orders, maar er is nog geen gecombineerde doorbreng-/retourflow of automatische synchronisatie tussen afdelingen.",
+      status: "partial",
+      improvements: [
+        "Doorvoer van gecombineerde doorbreng-/retour-opdrachten vereenvoudigen.",
+        "Automatische synchronisatie van orderupdates richting andere processen toevoegen.",
+      ],
+    },
+    {
+      id: "core-planning",
+      title: "Planning",
+      requirement: "Kanban-dashboard gecombineerd met kaartintegratie voor routeplanning.",
+      appSupport:
+        "Het planbord biedt Kanban-drag-and-drop en de routekaart visualiseert ritten, waarmee dit onderdeel functioneel wordt gedekt.",
+      status: "covered",
+      improvements: [],
+    },
+    {
+      id: "core-documents",
+      title: "Documenten",
+      requirement: "Automatisch genereren en mailen van rittenlijsten en CMR in PDF.",
+      appSupport:
+        "Documentgeneratie ontbreekt nog; er zijn geen export- of verzendopties voor rittenlijsten en CMR's.",
+      status: "missing",
+      improvements: [
+        "PDF-generator voor rittenlijsten en CMR koppelen aan planning en orders.",
+        "Automatische e-maildistributie met beheerbare sjablonen toevoegen.",
+      ],
+    },
+    {
+      id: "core-validation",
+      title: "Validatie",
+      requirement: "Geautomatiseerde processen voor offertes, orderbevestigingen en leverweken.",
+      appSupport:
+        "Er is geen workflow-engine of validatieproces; controles en verzending verlopen handmatig buiten de app.",
+      status: "missing",
+      improvements: [
+        "Workflows voor offerte- en ordervalidatie toevoegen met taken en notificaties.",
+        "Integratie voor automatische leverweekvalidatie realiseren.",
+      ],
+    },
+    {
+      id: "core-matching",
+      title: "Matching",
+      requirement:
+        "Automatische controle tussen orderbevestigingen en inkooporders met opvolgacties.",
+      appSupport:
+        "Het systeem biedt alleen handmatige statuswijziging; matching en opvolgacties ontbreken.",
+      status: "missing",
+      improvements: [
+        "Matchingregels en automatische afsluiting bij geslaagde matches implementeren.",
+        "Afhandelingsflow met verplicht commentaar bij no-match toevoegen.",
+      ],
+    },
+    {
+      id: "core-communication",
+      title: "Communicatie",
+      requirement: "Automatische e-mails naar klanten, leveranciers en interne medewerkers.",
+      appSupport:
+        "Notificaties zijn nog niet geautomatiseerd; communicatie gebeurt buiten de applicatie.",
+      status: "missing",
+      improvements: [
+        "Configurabele e-mailtemplates en triggers voor klanten en leveranciers opzetten.",
+        "In-app notificaties of taken voor interne medewerkers toevoegen.",
+      ],
+    },
+    {
+      id: "core-service-portal",
+      title: "Serviceportaal",
+      requirement: "Aanvragen, meldingen, accountbeheer en instructiebeheer vanuit één portaal.",
+      appSupport:
+        "Beheerders kunnen accounts beheren, maar er is geen klantgericht serviceportaal met meldingen en instructies.",
+      status: "partial",
+      improvements: [
+        "Serviceportaal voor klanten lanceren met inzage en wijzigingsmogelijkheden.",
+        "Module voor instructiebeheer en overzicht van servicemeldingen toevoegen.",
+      ],
+    },
+  ];
+
+  function createProcessCard(item) {
+    const article = document.createElement("article");
+    article.className = "process-card";
+    article.dataset.status = item.status;
+
+    const header = document.createElement("header");
+    header.className = "process-card-header";
+
+    const title = document.createElement("h3");
+    title.textContent = item.title;
+    header.appendChild(title);
+
+    const meta = STATUS_META[item.status] || STATUS_META.partial;
+    const badge = document.createElement("span");
+    badge.className = meta.className;
+    badge.textContent = meta.label;
+    header.appendChild(badge);
+
+    article.appendChild(header);
+
+    const requirement = document.createElement("p");
+    requirement.className = "process-requirement";
+    requirement.textContent = item.requirement;
+    article.appendChild(requirement);
+
+    const support = document.createElement("p");
+    support.className = "process-support";
+    support.textContent = item.appSupport;
+    article.appendChild(support);
+
+    if (Array.isArray(item.improvements) && item.improvements.length > 0) {
+      const listTitle = document.createElement("h4");
+      listTitle.textContent = "Aanvullende acties";
+      article.appendChild(listTitle);
+
+      const list = document.createElement("ul");
+      list.className = "improvement-list";
+      item.improvements.forEach((text) => {
+        const li = document.createElement("li");
+        li.textContent = text;
+        list.appendChild(li);
+      });
+      article.appendChild(list);
+    }
+
+    return article;
+  }
+
+  function renderList(targetId, items) {
+    const container = document.getElementById(targetId);
+    if (!container) return;
+    container.innerHTML = "";
+    items.forEach((item) => {
+      container.appendChild(createProcessCard(item));
+    });
+  }
+
+  function applyFilter(selectEl) {
+    if (!selectEl) return;
+    const targetId = selectEl.getAttribute("data-target");
+    if (!targetId) return;
+    const value = selectEl.value;
+    const container = document.getElementById(targetId);
+    if (!container) return;
+    const cards = container.querySelectorAll(".process-card");
+    cards.forEach((card) => {
+      if (value === "all") {
+        card.hidden = false;
+      } else {
+        card.hidden = card.dataset.status !== value;
+      }
+    });
+  }
+
+  function setupFilters() {
+    const filters = document.querySelectorAll(".status-filter");
+    filters.forEach((filter) => {
+      filter.addEventListener("change", () => applyFilter(filter));
+      applyFilter(filter);
+    });
+  }
+
+  function renderActions(items) {
+    const actionList = document.getElementById("actionList");
+    if (!actionList) return;
+    const actionMap = new Map();
+
+    items.forEach((item) => {
+      if (!Array.isArray(item.improvements)) return;
+      item.improvements.forEach((text) => {
+        const key = text.trim();
+        if (!key) return;
+        if (!actionMap.has(key)) {
+          actionMap.set(key, new Set());
+        }
+        actionMap.get(key).add(item.title);
+      });
+    });
+
+    actionList.innerHTML = "";
+
+    if (actionMap.size === 0) {
+      const li = document.createElement("li");
+      li.textContent = "Geen actiepunten toegevoegd.";
+      actionList.appendChild(li);
+      return;
+    }
+
+    actionMap.forEach((sources, text) => {
+      const li = document.createElement("li");
+      const spanText = document.createElement("span");
+      spanText.textContent = text;
+      li.appendChild(spanText);
+
+      if (sources.size > 0) {
+        const source = document.createElement("span");
+        source.className = "action-sources";
+        source.textContent = `(${Array.from(sources).join(", ")})`;
+        li.appendChild(source);
+      }
+
+      actionList.appendChild(li);
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    renderList("processList", PROCESS_DATA);
+    renderList("coreList", CORE_DATA);
+    setupFilters();
+    renderActions([...PROCESS_DATA, ...CORE_DATA]);
+  });
+})();

--- a/login.html
+++ b/login.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html">Planning</a>

--- a/orders.html
+++ b/orders.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html" class="active">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>

--- a/planning.html
+++ b/planning.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" class="active">Planning</a>

--- a/processen.html
+++ b/processen.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Transportplanner — Procesoverzicht</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body data-require-auth="true">
+  <header class="site-header">
+    <h1>Transportplanner</h1>
+    <div class="sub">Vergelijk gevraagde processen met de huidige app en bepaal vervolgstappen.</div>
+    <div class="header-actions">
+      <nav class="main-nav">
+        <a href="index.html">Start</a>
+        <a href="processen.html" class="active">Procesoverzicht</a>
+        <a href="aanvraag.html">Nieuwe aanvraag</a>
+        <a href="orders.html">Orders</a>
+        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
+        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
+        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
+        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+      </nav>
+      <div class="auth-area" id="authArea"></div>
+    </div>
+  </header>
+
+  <main class="page process-page">
+    <section class="card">
+      <h2>Samenvatting</h2>
+      <p>
+        Onderstaand overzicht zet de beschreven hoofdprocessen en functionele kernpunten naast de huidige stand van de
+        Transportplanner. Gebruik de statusindicatoren om snel te zien waar de app al voorziet en waar nog uitbreidingen
+        nodig zijn.
+      </p>
+      <p class="muted small">
+        Tip: gebruik de statusfilters om direct de hiaten te bekijken en vorm actiepunten voor ontwikkeling of procesinrichting.
+      </p>
+    </section>
+
+    <section class="card">
+      <div class="bar">
+        <h2>Hoofdprocessen</h2>
+        <label class="status-filter-label">
+          Statusfilter
+          <select id="processFilter" class="status-filter" data-target="processList">
+            <option value="all">Alle statussen</option>
+            <option value="missing">Alleen ontbrekend</option>
+            <option value="partial">Alleen gedeeltelijk</option>
+            <option value="covered">Alleen gedekt</option>
+          </select>
+        </label>
+      </div>
+      <div id="processList" class="process-grid" aria-live="polite"></div>
+    </section>
+
+    <section class="card">
+      <div class="bar">
+        <h2>Functionele kernpunten</h2>
+        <label class="status-filter-label">
+          Statusfilter
+          <select id="coreFilter" class="status-filter" data-target="coreList">
+            <option value="all">Alle statussen</option>
+            <option value="missing">Alleen ontbrekend</option>
+            <option value="partial">Alleen gedeeltelijk</option>
+            <option value="covered">Alleen gedekt</option>
+          </select>
+        </label>
+      </div>
+      <div id="coreList" class="process-grid" aria-live="polite"></div>
+    </section>
+
+    <section class="card">
+      <h2>Actiepunten vanuit vergelijking</h2>
+      <p>Deze lijst bundelt alle verbeterpunten en vormt een roadmap voor vervolgontwikkeling.</p>
+      <ul id="actionList" class="action-list"></ul>
+    </section>
+  </main>
+
+  <script src="js/config.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/processen.js"></script>
+</body>
+</html>

--- a/routekaart.html
+++ b/routekaart.html
@@ -19,6 +19,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>

--- a/styles.css
+++ b/styles.css
@@ -767,6 +767,139 @@ dialog::backdrop {
   letter-spacing: 0.06em;
 }
 
+.process-page {
+  gap: 28px;
+}
+
+.status-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.status-filter {
+  min-width: 180px;
+  padding: 8px 12px;
+}
+
+.process-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.process-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 100%;
+}
+
+.process-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.process-card-header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid transparent;
+}
+
+.status-badge.success {
+  background: rgba(46, 125, 50, 0.12);
+  color: var(--color-success);
+  border-color: rgba(46, 125, 50, 0.24);
+}
+
+.status-badge.warning {
+  background: rgba(242, 178, 102, 0.2);
+  color: #B85C00;
+  border-color: rgba(242, 178, 102, 0.32);
+}
+
+.status-badge.danger {
+  background: rgba(198, 40, 40, 0.12);
+  color: var(--color-error);
+  border-color: rgba(198, 40, 40, 0.24);
+}
+
+.process-requirement {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.process-support {
+  color: var(--color-muted);
+}
+
+.improvement-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.action-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.action-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: baseline;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  border: 1px dashed var(--color-border);
+}
+
+.action-sources {
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+@media (max-width: 720px) {
+  .status-filter-label {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .status-filter {
+    width: 100%;
+  }
+}
+
 .tag {
   display: inline-block;
   padding: 3px 8px;

--- a/users.html
+++ b/users.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>

--- a/vloot.html
+++ b/vloot.html
@@ -13,6 +13,7 @@
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html">Start</a>
+        <a href="processen.html">Procesoverzicht</a>
         <a href="aanvraag.html">Nieuwe aanvraag</a>
         <a href="orders.html">Orders</a>
         <a href="planning.html" data-role-visible="planner,admin">Planning</a>


### PR DESCRIPTION
## Summary
- add a Procesoverzicht entry to the global navigation and home dashboard
- introduce a Procesoverzicht page that compares requested processes with current app coverage and highlights action items
- style the new comparison view with reusable badges, grids, and action list formatting

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd281659b8832b956c1c097bcd9f2b