### PR TITLE
Fix route map by updating Leaflet SRI hashes

### DIFF
--- a/routekaart.html
+++ b/routekaart.html
@@ -8,7 +8,7 @@
   <link
     rel="stylesheet"
     href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-o9N1j7kGIC3NFZC0wE3VbZ8MaqkFkIB+3q4l9XELyXA="
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin=""
   />
 </head>
@@ -57,7 +57,7 @@
     </section>
   </main>
 
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-vYOQwY7Se7m0d9H9O8ndbWgP0iUGbm0M9EJ4tgiJT0A=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
   <script src="js/auth.js"></script>


### PR DESCRIPTION
## Summary
- update the Leaflet CDN integrity hashes on the routekaart page so the CSS/JS files load correctly

## Testing
- Manual: Loaded `routekaart.html` and confirmed the map renders with markers

------
https://chatgpt.com/codex/tasks/task_e_68dd4211e860832b82a23cb38da8a2df