### PR TITLE
Improve mobile overview layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -214,6 +214,7 @@ h4 {
     position: sticky;
     top: 0;
     z-index: 10;
+    text-align: center;
   }
 
   .site-header h1 {
@@ -232,22 +233,15 @@ h4 {
 
   .main-nav {
     width: 100%;
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: 8px;
-    padding-bottom: 4px;
-    scroll-snap-type: x proximity;
-    -webkit-overflow-scrolling: touch;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
   }
 
   .main-nav a {
-    font-size: 14px;
-    padding: 10px 12px;
+    font-size: 15px;
+    padding: 12px 14px;
     text-align: center;
-    flex: 0 0 auto;
-    scroll-snap-align: start;
-    white-space: nowrap;
   }
 
   .auth-area {
@@ -266,6 +260,23 @@ h4 {
 
   .card {
     padding: 16px;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-card {
+    text-align: left;
+  }
+
+  .nav-card h3 {
+    font-size: 18px;
+  }
+
+  .nav-card p {
+    font-size: 14px;
+    line-height: 1.6;
   }
 
   .bar {


### PR DESCRIPTION
## Summary
- adjust the mobile breakpoint styles to center the header and present navigation links in an easy-to-tap grid
- widen mobile navigation buttons and typography to improve readability on phones
- force the overview cards into a single column with balanced text sizing on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd86d1b02c832b96309229b4ae3a40