### PR TITLE
Fix mobile form layout responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -285,10 +285,6 @@ h4 {
     gap: 8px;
   }
 
-  .grid3 {
-    grid-template-columns: 1fr;
-  }
-
   .plan-controls {
     width: 100%;
   }
@@ -327,6 +323,7 @@ h4 {
 
 .checkbox {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
   font-size: 14px;
@@ -384,6 +381,7 @@ h4 {
 
 .toggle-option {
   display: inline-flex;
+  flex-direction: row;
   align-items: center;
   gap: 6px;
   padding: 6px 14px;
@@ -450,16 +448,20 @@ h4 {
 }
 
 label {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   margin: 8px 0;
   color: var(--color-muted);
   font-weight: 500;
+  min-width: 0;
 }
 
 input,
 select,
 textarea {
   width: 100%;
+  min-width: 0;
   padding: 10px 12px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -548,7 +550,7 @@ textarea {
 .grid2 {
   display: grid;
   gap: 12px;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 @media (max-width: 760px) {
@@ -565,19 +567,25 @@ textarea {
 .grid3 {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 @media (max-width: 900px) {
   .grid3 {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .grid3 {
+    grid-template-columns: 1fr;
   }
 }
 
 .grid4 {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 @media (max-width: 1100px) {
@@ -955,6 +963,7 @@ dialog::backdrop {
 
 .status-filter-label {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- allow form labels and inputs to flow in a column layout so fields resize cleanly on narrow screens
- update shared grid utilities to use minmax columns and ensure mobile breakpoints apply in the correct order

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dd915918d8832bbf37a3f6ff59fe5c