### PR TITLE
Restyle header navigation with compact icon buttons

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -12,14 +12,95 @@
     <div class="sub">Leg nieuwe transportaanvragen vast inclusief alle details.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html" class="active">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag" class="active">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/create-user.html
+++ b/create-user.html
@@ -12,14 +12,95 @@
     <div class="sub">Gebruik je eigen admin-account om een planner of werknemer toe te voegen.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html">Planning</a>
-        <a href="routekaart.html">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,14 +12,95 @@
     <div class="sub">Complete workflow voor transportaanvragen, vrachtwagenbeheer en planning.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html" class="active">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start" class="active">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/login.html
+++ b/login.html
@@ -12,14 +12,95 @@
     <div class="sub">Log in om toegang te krijgen tot de modules.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html">Planning</a>
-        <a href="routekaart.html">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/orders.html
+++ b/orders.html
@@ -12,14 +12,95 @@
     <div class="sub">Bekijk en bewerk bestaande transporten.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html" class="active">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders" class="active">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/planning.html
+++ b/planning.html
@@ -12,14 +12,95 @@
     <div class="sub">Plan transporten in op basis van capaciteit en beschikbaarheid.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" class="active">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" class="active" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/processen.html
+++ b/processen.html
@@ -12,14 +12,95 @@
     <div class="sub">Vergelijk gevraagde processen met de huidige app en bepaal vervolgstappen.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html" class="active">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht" class="active">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/routekaart.html
+++ b/routekaart.html
@@ -18,14 +18,95 @@
     <div class="sub">Visualiseer geplande ritten en optimaliseer routes per vrachtwagen.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" class="active" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" class="active" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -87,29 +87,54 @@ h4 {
 .main-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
 }
 
 .main-nav a {
-  padding: 10px 18px;
-  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
   text-decoration: none;
-  color: var(--color-text);
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
+  color: var(--color-muted);
+  background: transparent;
+  border: 1px solid transparent;
   font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  font-size: 14px;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.main-nav a:hover {
-  background: var(--color-surface);
-  border-color: var(--color-primary);
+.main-nav a:hover,
+.main-nav a:focus-visible {
+  color: var(--color-text);
+  background: var(--color-background);
+  border-color: var(--color-border);
 }
 
 .main-nav a.active {
-  background: var(--color-primary);
   color: #ffffff;
+  background: var(--color-primary);
   border-color: var(--color-primary);
+  box-shadow: 0 6px 18px rgba(226, 0, 26, 0.25);
+}
+
+.main-nav .nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.main-nav .nav-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.main-nav .nav-label {
+  white-space: nowrap;
 }
 
 .auth-area {
@@ -233,15 +258,27 @@ h4 {
 
   .main-nav {
     width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 10px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    justify-content: flex-start;
+    gap: 6px;
+    padding-bottom: 4px;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .main-nav::-webkit-scrollbar {
+    display: none;
   }
 
   .main-nav a {
-    font-size: 15px;
-    padding: 12px 14px;
-    text-align: center;
+    flex: 0 0 auto;
+    font-size: 13px;
+    padding: 8px 10px;
+  }
+
+  .main-nav .nav-label {
+    font-size: 12px;
   }
 
   .auth-area {

--- a/users.html
+++ b/users.html
@@ -12,14 +12,95 @@
     <div class="sub">Beheer inloggegevens en rollen voor de transportplanner.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="active nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users active" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>

--- a/vloot.html
+++ b/vloot.html
@@ -12,14 +12,95 @@
     <div class="sub">Beheer lokale vrachtwagens en registreer externe carriers.</div>
     <div class="header-actions">
       <nav class="main-nav">
-        <a href="index.html">Start</a>
-        <a href="processen.html">Procesoverzicht</a>
-        <a href="aanvraag.html">Nieuwe aanvraag</a>
-        <a href="orders.html">Orders</a>
-        <a href="planning.html" data-role-visible="planner,admin">Planning</a>
-        <a href="routekaart.html" data-role-visible="planner,admin">Routekaart</a>
-        <a href="vloot.html" class="active" data-role-visible="admin">Vloot &amp; carriers</a>
-        <a href="users.html" class="nav-users" data-role-visible="admin">Gebruikers</a>
+        <a href="index.html" aria-label="Start">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 10.5 12 3l9 7.5" />
+                      <path d="M5 9v11a1 1 0 0 0 1 1h3.5V15h4v6H17a1 1 0 0 0 1-1V9" />
+                    </svg>
+          </span>
+          <span class="nav-label">Start</span>
+        </a>
+        <a href="processen.html" aria-label="Procesoverzicht">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="6" cy="6" r="2.5" />
+                      <circle cx="18" cy="6" r="2.5" />
+                      <circle cx="6" cy="18" r="2.5" />
+                      <circle cx="18" cy="18" r="2.5" />
+                      <path d="M8.5 6h7" />
+                      <path d="M6 8.5v7" />
+                      <path d="M18 8.5v7" />
+                      <path d="M8.5 18h7" />
+                    </svg>
+          </span>
+          <span class="nav-label">Procesoverzicht</span>
+        </a>
+        <a href="aanvraag.html" aria-label="Nieuwe aanvraag">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="7.5" />
+                      <path d="M12 8v8" />
+                      <path d="M8 12h8" />
+                    </svg>
+          </span>
+          <span class="nav-label">Nieuwe aanvraag</span>
+        </a>
+        <a href="orders.html" aria-label="Orders">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M9 7h10" />
+                      <path d="M9 12h10" />
+                      <path d="M9 17h10" />
+                      <circle cx="5" cy="7" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+                      <circle cx="5" cy="17" r="1" fill="currentColor" stroke="none" />
+                    </svg>
+          </span>
+          <span class="nav-label">Orders</span>
+        </a>
+        <a href="planning.html" aria-label="Planning" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="4" y="5" width="16" height="15" rx="2" />
+                      <path d="M8 3v4" />
+                      <path d="M16 3v4" />
+                      <path d="M4 10h16" />
+                    </svg>
+          </span>
+          <span class="nav-label">Planning</span>
+        </a>
+        <a href="routekaart.html" aria-label="Routekaart" data-role-visible="planner,admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 6.5 9 4l6 2.5 6-2.5v13l-6 2.5-6-2.5-6 2.5z" />
+                      <path d="M9 4v13" />
+                      <path d="M15 6.5v13" />
+                    </svg>
+          </span>
+          <span class="nav-label">Routekaart</span>
+        </a>
+        <a href="vloot.html" aria-label="Vloot & carriers" class="active" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M3 7h11v10H3z" />
+                      <path d="M14 10h3.5L21 13v4h-7" />
+                      <circle cx="7.5" cy="17" r="1.5" />
+                      <circle cx="17.5" cy="17" r="1.5" />
+                    </svg>
+          </span>
+          <span class="nav-label">Vloot & carriers</span>
+        </a>
+        <a href="users.html" aria-label="Gebruikers" class="nav-users" data-role-visible="admin">
+          <span class="nav-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="7.5" r="2.5" />
+                      <path d="M7.5 13a4.5 4.5 0 0 1 9 0" />
+                      <path d="M5 19.5a7 7 0 0 1 14 0" />
+                    </svg>
+          </span>
+          <span class="nav-label">Gebruikers</span>
+        </a>
       </nav>
       <div class="auth-area" id="authArea"></div>
     </div>


### PR DESCRIPTION
## Summary
- replace the header navigation links with icon-backed buttons on every page to minimise the header footprint
- refresh the navigation styles for a slimmer presentation with icon sizing and focus states
- add responsive tweaks so the new buttons scroll horizontally on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd94c5f34c832ba4fa20947d90fd5e