### PR TITLE
Add article type selection and multi-item support

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -118,24 +118,14 @@
             <label>Transport aanvraag referentie
               <input id="oRequestReference" placeholder="Bijv. TAR-2024-001" />
             </label>
-            <label>Transport type
-              <select id="oTransportType">
-                <option value="">Selecteer...</option>
-                <option>Complete lading</option>
-                <option>Deellading</option>
-                <option>Koeltransport</option>
-                <option>ADR</option>
-                <option>Exceptioneel vervoer</option>
+            <label>Betreft
+              <select id="oTransportType" disabled>
+                <option value="Afleveren" selected>Afleveren</option>
               </select>
             </label>
             <label>Status
-              <select id="oStatus">
-                <option>Nieuw</option>
-                <option>Te plannen</option>
-                <option>Gepland</option>
-                <option>In transport</option>
-                <option>Geleverd</option>
-                <option>Geannuleerd</option>
+              <select id="oStatus" disabled>
+                <option value="Nieuw" selected>Nieuw</option>
               </select>
             </label>
           </div>
@@ -188,10 +178,6 @@
                 <input type="radio" name="pickupMode" value="existing" checked />
                 <span>Bestaande laadlocatie</span>
               </label>
-              <label class="toggle-option">
-                <input type="radio" name="pickupMode" value="new" />
-                <span>Nieuwe laadlocatie</span>
-              </label>
             </div>
           </div>
           <div class="grid3">
@@ -233,10 +219,6 @@
                 <input type="radio" name="deliveryMode" value="existing" checked />
                 <span>Bestaand losadres</span>
               </label>
-              <label class="toggle-option">
-                <input type="radio" name="deliveryMode" value="new" />
-                <span>Nieuw losadres</span>
-              </label>
             </div>
           </div>
           <div class="grid3">
@@ -270,7 +252,21 @@
         </section>
 
         <section class="form-section">
-          <h4 class="section-title">Transport regel</h4>
+          <h4 class="section-title">Artikelen</h4>
+          <p class="muted small">Selecteer of het om serienummer gebonden of niet serienummer gebonden artikelen gaat en voeg alle artikelen toe.</p>
+          <div class="form-toggle">
+            <span class="toggle-label">Artikeltype</span>
+            <div class="toggle-group">
+              <label class="toggle-option">
+                <input type="radio" name="articleType" value="serial" id="articleTypeSerial" />
+                <span>Serienummer gebonden artikel</span>
+              </label>
+              <label class="toggle-option">
+                <input type="radio" name="articleType" value="non_serial" id="articleTypeNonSerial" />
+                <span>Niet serienummer gebonden artikel</span>
+              </label>
+            </div>
+          </div>
           <div class="grid3">
             <label>Pallets
               <input id="oPallets" type="number" min="0" step="1" />
@@ -282,21 +278,31 @@
               <input id="oVolume" type="number" min="0" step="0.1" />
             </label>
           </div>
-          <details>
-            <summary>Extra transportregel toevoegen (optioneel)</summary>
-            <div class="grid3">
-              <label>Product / omschrijving
-                <input id="lProduct" placeholder="Bijv. Heftruck, reachtruck" />
+          <div id="articleList" class="article-list"></div>
+          <button type="button" class="btn ghost" id="btnAddArticle">Artikel toevoegen</button>
+        </section>
+
+        <template id="articleRowTemplate">
+          <div class="article-row">
+            <div class="grid4">
+              <label>Artikel
+                <input data-field="product" placeholder="Bijv. Heftruck, reachtruck" />
               </label>
-              <label>Aantal
-                <input id="lQty" type="number" min="1" value="1" />
+              <label class="serial-field">Serienummer
+                <input data-field="serial_number" placeholder="Bijv. HFT-001234" />
+              </label>
+              <label class="quantity-field">Aantal
+                <input data-field="quantity" type="number" min="1" value="1" />
               </label>
               <label>Gewicht (kg)
-                <input id="lWeight" type="number" min="0" step="0.1" value="0" />
+                <input data-field="weight" type="number" min="0" step="0.1" />
               </label>
             </div>
-          </details>
-        </section>
+            <div class="article-row-actions">
+              <button type="button" class="btn ghost small" data-action="remove-article">Verwijderen</button>
+            </div>
+          </div>
+        </template>
 
         <div class="form-actions">
           <button id="btnCreate" type="button" class="btn primary">Transport opslaan</button>

--- a/styles.css
+++ b/styles.css
@@ -384,6 +384,34 @@ h4 {
   gap: 16px;
 }
 
+.article-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.article-row {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.article-row .article-row-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.article-row .quantity-field.is-readonly input {
+  background: var(--color-background);
+  cursor: not-allowed;
+  color: var(--color-muted);
+}
+
 .form-field-full {
   grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- add an artikeltype choice and dynamic artikel rows to the aanvraag form so multiple serialized or non-serialized items can be captured
- extend the client logic to manage and validate the article list, store the type on the order, and create all line items
- update the Supabase schema to persist article_type and serial_number details for orders and lines

## Testing
- not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_68dd98ead03c832b905d0fbb64970822