### PR TITLE
Improve Supabase error handling

### DIFF
--- a/js/create-user.js
+++ b/js/create-user.js
@@ -90,7 +90,10 @@
         }
       } catch (err) {
         console.error(err);
-        setCreateStatus(err.message || "Gebruiker aanmaken mislukt", "error");
+        const message = window.ApiHelpers?.formatSupabaseError
+          ? window.ApiHelpers.formatSupabaseError(err, "Gebruiker aanmaken mislukt")
+          : err?.message || "Gebruiker aanmaken mislukt";
+        setCreateStatus(message, "error");
       } finally {
         if (btnCreate) {
           btnCreate.disabled = false;

--- a/js/users.js
+++ b/js/users.js
@@ -128,7 +128,10 @@
       await loadUsers(false);
     } catch (err) {
       console.error(err);
-      setStatus("Opslaan mislukt: " + (err.message || "onbekende fout"), "error");
+      const message = window.ApiHelpers?.formatSupabaseError
+        ? window.ApiHelpers.formatSupabaseError(err, "onbekende fout")
+        : err?.message || "onbekende fout";
+      setStatus(`Opslaan mislukt: ${message}`, "error");
     }
   }
 


### PR DESCRIPTION
## Summary
- add a reusable Supabase error formatter that recognises duplicate email violations
- surface friendlier error messages when creating users through the admin and request forms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda4c7a874832bae67260aa69b372f