### PR TITLE
Remove cargo size inputs

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -267,24 +267,13 @@
               </label>
             </div>
           </div>
-          <div class="grid3">
-            <label>Pallets
-              <input id="oPallets" type="number" min="0" step="1" />
-            </label>
-            <label>Gewicht (kg)
-              <input id="oWeight" type="number" min="0" step="0.1" />
-            </label>
-            <label>Volume (m³)
-              <input id="oVolume" type="number" min="0" step="0.1" />
-            </label>
-          </div>
           <div id="articleList" class="article-list"></div>
           <button type="button" class="btn ghost" id="btnAddArticle">Artikel toevoegen</button>
         </section>
 
         <template id="articleRowTemplate">
           <div class="article-row">
-            <div class="grid4">
+            <div class="grid3">
               <label>Artikel
                 <input data-field="product" placeholder="Bijv. Heftruck, reachtruck" />
               </label>
@@ -293,9 +282,6 @@
               </label>
               <label class="quantity-field">Aantal
                 <input data-field="quantity" type="number" min="1" value="1" />
-              </label>
-              <label>Gewicht (kg)
-                <input data-field="weight" type="number" min="0" step="0.1" />
               </label>
             </div>
             <div class="article-row-actions">

--- a/js/routes.js
+++ b/js/routes.js
@@ -201,8 +201,7 @@
       card.appendChild(header);
       const meta = document.createElement("div");
       meta.className = "muted small";
-      const weightText = group.weightKnown ? `${group.totalWeight.toFixed(0)} kg` : "onbekend gewicht";
-      meta.textContent = `Afstand ${group.distance.toFixed(1)} km • Gewicht ${weightText}`;
+      meta.textContent = `Afstand ${group.distance.toFixed(1)} km`;
       card.appendChild(meta);
       const list = document.createElement("ul");
       for (const stop of group.stops){
@@ -329,17 +328,10 @@
         const polylinePoints = [ [hub.lat, hub.lng] ];
         let distance = 0;
         let cursor = { lat: hub.lat, lng: hub.lng };
-        let totalWeight = 0;
-        let weightKnown = false;
         for (const stop of orderedStops){
           polylinePoints.push([stop.latlng.lat, stop.latlng.lng]);
           distance += haversine(cursor, stop.latlng);
           cursor = stop.latlng;
-          const weight = stop.details?.cargo?.weight;
-          if (Number.isFinite(weight)) {
-            totalWeight += weight;
-            weightKnown = true;
-          }
         }
         polylinePoints.push([hub.lat, hub.lng]);
         distance += haversine(cursor, { lat: hub.lat, lng: hub.lng });
@@ -360,8 +352,6 @@
           label: carrier,
           stops: orderedStops,
           distance,
-          totalWeight,
-          weightKnown,
           color,
         });
       }

--- a/supabase_transport.sql
+++ b/supabase_transport.sql
@@ -57,9 +57,6 @@ create table if not exists public.transport_orders (
   delivery_instructions text,
   load_type text,
   cargo_type text,
-  pallets integer,
-  weight_kg numeric,
-  volume_m3 numeric,
   instructions text,
   notes text,
   article_type text,
@@ -112,9 +109,6 @@ alter table public.transport_orders add column if not exists delivery_contact_ph
 alter table public.transport_orders add column if not exists delivery_instructions text;
 alter table public.transport_orders add column if not exists load_type text;
 alter table public.transport_orders add column if not exists cargo_type text;
-alter table public.transport_orders add column if not exists pallets integer;
-alter table public.transport_orders add column if not exists weight_kg numeric;
-alter table public.transport_orders add column if not exists volume_m3 numeric;
 alter table public.transport_orders add column if not exists instructions text;
 alter table public.transport_orders add column if not exists notes text;
 alter table public.transport_orders add column if not exists article_type text;
@@ -202,12 +196,10 @@ create table if not exists public.transport_lines (
   order_id bigint not null references public.transport_orders(id) on delete cascade,
   product text not null,
   quantity integer not null default 1,
-  weight_kg numeric,
   serial_number text,
   article_type text
 );
 
-alter table public.transport_lines add column if not exists weight_kg numeric;
 alter table public.transport_lines add column if not exists quantity integer;
 alter table public.transport_lines alter column quantity set default 1;
 alter table public.transport_lines add column if not exists serial_number text;


### PR DESCRIPTION
## Summary
- remove pallets, weight and volume inputs from the order form and article template
- strip associated order payload handling and Supabase schema columns
- simplify route summaries now that cargo weight is no longer tracked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de0b312e20832bae7b8ec010b00013