### PR TITLE
Remove redundant header subtitles from all pages

### DIFF
--- a/aanvraag.html
+++ b/aanvraag.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Leg nieuwe transportaanvragen vast inclusief alle details.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/create-user.html
+++ b/create-user.html
@@ -9,7 +9,6 @@
 <body>
   <header class="site-header">
     <h1>Nieuwe gebruiker aanmaken</h1>
-    <div class="sub">Gebruik je eigen admin-account om een planner of werknemer toe te voegen.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Complete workflow voor transportaanvragen, vrachtwagenbeheer en planning.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start" class="active">

--- a/login.html
+++ b/login.html
@@ -9,7 +9,6 @@
 <body>
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Log in om toegang te krijgen tot de modules.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/orders.html
+++ b/orders.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Bekijk en bewerk bestaande transporten.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/planning.html
+++ b/planning.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true" data-require-role="planner,admin">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Plan transporten in op basis van capaciteit en beschikbaarheid.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/processen.html
+++ b/processen.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Vergelijk gevraagde processen met de huidige app en bepaal vervolgstappen.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/routekaart.html
+++ b/routekaart.html
@@ -15,7 +15,6 @@
 <body data-require-auth="true" data-require-role="planner,admin">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Visualiseer geplande ritten en optimaliseer routes per vrachtwagen.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/users.html
+++ b/users.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true" data-require-role="admin">
   <header class="site-header">
     <h1>Gebruikersbeheer</h1>
-    <div class="sub">Beheer inloggegevens en rollen voor de transportplanner.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">

--- a/vloot.html
+++ b/vloot.html
@@ -9,7 +9,6 @@
 <body data-require-auth="true" data-require-role="admin">
   <header class="site-header">
     <h1>Transportplanner</h1>
-    <div class="sub">Beheer lokale vrachtwagens en registreer externe carriers.</div>
     <div class="header-actions">
       <nav class="main-nav">
         <a href="index.html" aria-label="Start">


### PR DESCRIPTION
## Summary
- remove the descriptive header subtitle from each page so that only the main header remains

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de19e03214832bab36f1f735de5a84