### PR TITLE
Prevent inactive admins from creating users

### DIFF
--- a/js/create-user.js
+++ b/js/create-user.js
@@ -95,6 +95,11 @@
       if (!adminUser || adminUser.role !== "admin") {
         throw new Error("Alleen admins kunnen nieuwe gebruikers aanmaken");
       }
+      if (!adminUser.is_active) {
+        throw new Error(
+          "Dit admin-account is gedeactiveerd. Neem contact op met een beheerder voor ondersteuning."
+        );
+      }
 
       const newPasswordHash = await window.Auth.hashPassword(newPasswordValue);
       await window.Users.create({


### PR DESCRIPTION
## Summary
- ensure admin accounts are validated for active status before creating users
- surface a clear error message when a deactivated admin tries to add a user

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de27d9ead4832bad5dd741fa96253b