### PR TITLE
Hide received date input from new request form

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -18,9 +18,7 @@
           <input id="oStatus" type="hidden" value="Nieuw" />
         </div>
         <div class="grid3">
-          <label>Transportaanvraag ontvangen op
-            <input id="oReceivedAt" type="date" />
-          </label>
+          <input id="oReceivedAt" type="hidden" />
           <label>Gewenste leverdatum
             <input id="oDue" type="date" />
           </label>


### PR DESCRIPTION
## Summary
- hide the transport request received date input field from the aanvraag form while keeping it populated in the background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de425e4034832bb5f073c08256b740