### PR TITLE
Switch to Dutch date formatting with shared utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
 
   <main id="appRoot" aria-live="polite" aria-busy="true"></main>
 
+  <script src="js/date-utils.js"></script>
   <script src="js/config.js"></script>
   <script src="js/api.js"></script>
   <script src="js/auth.js"></script>

--- a/js/date-utils.js
+++ b/js/date-utils.js
@@ -1,0 +1,145 @@
+(function () {
+  const pad = (value) => String(value).padStart(2, "0");
+
+  function parseDateParts(value) {
+    if (!value && value !== 0) return null;
+    if (value instanceof Date) {
+      if (Number.isNaN(value.getTime())) return null;
+      return {
+        year: value.getFullYear(),
+        month: value.getMonth() + 1,
+        day: value.getDate(),
+      };
+    }
+    if (typeof value === "object" && value && "year" in value && "month" in value && "day" in value) {
+      const year = Number(value.year);
+      const month = Number(value.month);
+      const day = Number(value.day);
+      if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+        return null;
+      }
+      return { year, month, day };
+    }
+    const text = String(value).trim();
+    if (!text) return null;
+
+    const isoMatch = text.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s].*)?$/);
+    if (isoMatch) {
+      return {
+        year: Number(isoMatch[1]),
+        month: Number(isoMatch[2]),
+        day: Number(isoMatch[3]),
+      };
+    }
+
+    const nlMatch = text.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+    if (nlMatch) {
+      return {
+        year: Number(nlMatch[3]),
+        month: Number(nlMatch[2]),
+        day: Number(nlMatch[1]),
+      };
+    }
+
+    return null;
+  }
+
+  function formatDateDisplay(value) {
+    const parts = parseDateParts(value);
+    if (!parts) return "-";
+    const { year, month, day } = parts;
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return "-";
+    return `${pad(day)}-${pad(month)}-${year}`;
+  }
+
+  function formatDateForInput(value) {
+    const parts = parseDateParts(value);
+    if (!parts) return "";
+    const { year, month, day } = parts;
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return "";
+    return `${year}-${pad(month)}-${pad(day)}`;
+  }
+
+  function ensureDate(value) {
+    if (!value && value !== 0) return null;
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const parsed = Date.parse(trimmed);
+      if (!Number.isNaN(parsed)) {
+        return new Date(parsed);
+      }
+    }
+    const parts = parseDateParts(value);
+    if (!parts) return null;
+    const { year, month, day } = parts;
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+    return new Date(year, month - 1, day);
+  }
+
+  const DATE_TIME_FORMATTER = new Intl.DateTimeFormat("nl-NL", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  function formatDateTimeDisplay(value) {
+    const date = ensureDate(value);
+    if (!date) return "-";
+    return DATE_TIME_FORMATTER.format(date).replace(/[\u202F\u00A0]/g, " ");
+  }
+
+  function getTodayDateValue() {
+    const now = new Date();
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  }
+
+  function createKeypressHandler(event) {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    event.preventDefault();
+  }
+
+  function createBeforeInputHandler(event) {
+    if (event.inputType && event.inputType.startsWith("insert")) {
+      event.preventDefault();
+    }
+  }
+
+  function handleKeyDown(event) {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.key && event.key.length === 1) {
+      event.preventDefault();
+    }
+  }
+
+  function enforceDateInput(input) {
+    if (!input || input.dataset.datePickerEnforced === "true") return;
+    input.setAttribute("lang", "nl");
+    input.setAttribute("inputmode", "none");
+    input.dataset.datePickerEnforced = "true";
+    input.addEventListener("keypress", createKeypressHandler);
+    input.addEventListener("keydown", handleKeyDown);
+    input.addEventListener("beforeinput", createBeforeInputHandler);
+  }
+
+  function enforceDateInputs(root) {
+    const scope = root || document;
+    const inputs = scope.querySelectorAll ? scope.querySelectorAll('input[type="date"]') : [];
+    inputs.forEach(enforceDateInput);
+  }
+
+  window.DateUtils = {
+    parseDateParts,
+    formatDateDisplay,
+    formatDateForInput,
+    formatDateTimeDisplay,
+    getTodayDateValue,
+    ensureDate,
+    enforceDateInputs,
+  };
+})();

--- a/js/router.js
+++ b/js/router.js
@@ -193,6 +193,9 @@
       if (window.Auth && typeof window.Auth.applyRoleVisibility === "function") {
         window.Auth.applyRoleVisibility();
       }
+      if (window.DateUtils && typeof window.DateUtils.enforceDateInputs === "function") {
+        window.DateUtils.enforceDateInputs(rootElement || appRoot);
+      }
       currentRoute = routeKey;
       const module = getPageModule(routeKey);
       if (module && typeof module.init === "function") {

--- a/js/routes.js
+++ b/js/routes.js
@@ -1,6 +1,33 @@
 (function () {
   window.Pages = window.Pages || {};
 
+  const DATE_UTILS = window.DateUtils || {};
+  const formatDateDisplay = typeof DATE_UTILS.formatDateDisplay === "function"
+    ? DATE_UTILS.formatDateDisplay
+    : (value) => {
+        if (!value) return "-";
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return typeof value === "string" && value.trim() ? value : "-";
+        }
+        const day = String(date.getDate()).padStart(2, "0");
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const year = date.getFullYear();
+        return `${day}-${month}-${year}`;
+      };
+  const getTodayDateValue = typeof DATE_UTILS.getTodayDateValue === "function"
+    ? DATE_UTILS.getTodayDateValue
+    : () => {
+        const today = new Date();
+        const day = String(today.getDate()).padStart(2, "0");
+        const month = String(today.getMonth() + 1).padStart(2, "0");
+        const year = today.getFullYear();
+        return `${year}-${month}-${day}`;
+      };
+  const enforceDateInputs = typeof DATE_UTILS.enforceDateInputs === "function"
+    ? DATE_UTILS.enforceDateInputs
+    : () => {};
+
   function refreshElements(root) {
     const scope = root || document;
     return {
@@ -110,10 +137,10 @@
   }
 
   function ensureDate() {
-    if (!els.date) return new Date().toISOString().slice(0, 10);
+    if (!els.date) return getTodayDateValue();
     let value = els.date.value;
     if (!value) {
-      value = new Date().toISOString().slice(0, 10);
+      value = getTodayDateValue();
       els.date.value = value;
     }
     return value;
@@ -264,7 +291,7 @@
       backlog.appendChild(header);
       const hint = document.createElement("div");
       hint.className = "muted small";
-      hint.textContent = `Deze opdrachten staan nog los van een voertuig op ${new Date(date).toLocaleDateString("nl-NL")}.`;
+      hint.textContent = `Deze opdrachten staan nog los van een voertuig op ${formatDateDisplay(date)}.`;
       backlog.appendChild(hint);
       const list = document.createElement("ul");
       for (const stop of unplanned) {
@@ -403,7 +430,7 @@
       }
 
       renderSummary(grouped, backlog, date);
-      setStatus(`Kaart bijgewerkt voor ${new Date(date).toLocaleDateString("nl-NL")}.`, "success");
+      setStatus(`Kaart bijgewerkt voor ${formatDateDisplay(date)}.`, "success");
     } catch (e) {
       console.error("Kan routes niet laden", e);
       setStatus("Routes laden mislukt. Probeer het opnieuw.", "error");
@@ -421,6 +448,7 @@
 
   async function init(context = {}) {
     els = refreshElements(context.root || document);
+    enforceDateInputs(context.root || document);
     if (!els.map) {
       return;
     }

--- a/js/users.js
+++ b/js/users.js
@@ -1,6 +1,21 @@
 (function () {
   window.Pages = window.Pages || {};
 
+  const DATE_UTILS = window.DateUtils || {};
+  const formatDateTimeDisplay = typeof DATE_UTILS.formatDateTimeDisplay === "function"
+    ? DATE_UTILS.formatDateTimeDisplay
+    : (value) => {
+        if (!value) return "-";
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return "-";
+        const day = String(date.getDate()).padStart(2, "0");
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const year = date.getFullYear();
+        const hours = String(date.getHours()).padStart(2, "0");
+        const minutes = String(date.getMinutes()).padStart(2, "0");
+        return `${day}-${month}-${year} ${hours}:${minutes}`;
+      };
+
   function refreshElements(root) {
     const scope = root || document;
     return {
@@ -57,12 +72,11 @@
 
   function formatDate(value) {
     if (!value) return "-";
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return value;
-    return date.toLocaleString("nl-NL", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    });
+    const formatted = formatDateTimeDisplay(value);
+    if (!formatted || formatted === "-") {
+      return typeof value === "string" && value.trim() ? value : "-";
+    }
+    return formatted;
   }
 
   function renderUsers(users) {


### PR DESCRIPTION
## Summary
- add a shared date utility that formats dd-mm-jjjj, parses input, and disables manual typing on date inputs
- load the utility across the app and update core pages to use the shared functions for defaults, formatting, and picker enforcement
- align users and route views with the Dutch date display and shared picker behavior

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68deb716a5dc832b9a5268bf30f8f16c