### PR TITLE
Load Supabase config from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in the values for your Supabase project.
+SUPABASE_URL="https://your-project-id.supabase.co/rest/v1"
+SUPABASE_ANON_KEY="your-anon-key"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Environment configuration
+.env
+js/env.js
+
+# Dependencies
+node_modules/
+
+# Build output
+/dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Motrac Transport
+
+## Configuratie
+
+1. Kopieer `.env.example` naar `.env` en vul de Supabase waarden in.
+2. Genereer het runtime configuratiebestand met:
+   ```bash
+   npm install
+   npm run build:env
+   ```
+   > `npm install` is alleen nodig bij de eerste keer om eventuele toekomstige afhankelijkheden te installeren.
+3. Start de applicatie via je gewenste webserver. Het script `npm run build:env` maakt `js/env.js` aan dat door de app wordt gelezen.
+
+De gegenereerde `js/env.js` en `.env` staan in `.gitignore` zodat sleutels niet per ongeluk in de repository terechtkomen.

--- a/index.html
+++ b/index.html
@@ -114,6 +114,10 @@
   <main id="appRoot" aria-live="polite" aria-busy="true"></main>
 
   <script src="js/date-utils.js"></script>
+  <script>
+    window.__APP_ENV__ = window.__APP_ENV__ || {};
+  </script>
+  <script src="js/env.js"></script>
   <script src="js/config.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.45.4/dist/umd/supabase.min.js" crossorigin="anonymous"></script>
   <script src="js/api.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,23 @@
-window.APP_CONFIG = {
-  SUPABASE_URL: "https://ezcxfobjsvomcjuwbgep.supabase.co/rest/v1",
-  SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV6Y3hmb2Jqc3ZvbWNqdXdiZ2VwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2NzQ3ODcsImV4cCI6MjA3MzI1MDc4N30.IhYZYfB_N2JDOG82NFbB_wxY7BJhahqJd9Y71nhpI3I"
-};
+(function () {
+  const sourceEnv = (typeof window !== "undefined" && window.__APP_ENV__) || {};
+
+  const config = {
+    SUPABASE_URL: typeof sourceEnv.SUPABASE_URL === "string" ? sourceEnv.SUPABASE_URL.trim() : "",
+    SUPABASE_ANON_KEY:
+      typeof sourceEnv.SUPABASE_ANON_KEY === "string" ? sourceEnv.SUPABASE_ANON_KEY.trim() : "",
+  };
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    const message =
+      "Configuration missing: " +
+      `${missing.join(", ")}. Did you run \"npm run build:env\" with the required environment variables?`;
+    console.error(message);
+    throw new Error(message);
+  }
+
+  window.APP_CONFIG = Object.freeze(config);
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "motrac-transport",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "motrac-transport",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "motrac-transport",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:env": "node scripts/build-env.js"
+  }
+}

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -1,0 +1,82 @@
+const fs = require("fs");
+const path = require("path");
+
+const ENV_OUTPUT_PATH = path.resolve(__dirname, "..", "js", "env.js");
+const ENV_FILE_PATH = path.resolve(__dirname, "..", ".env");
+
+function parseEnv(contents) {
+  return contents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .reduce((acc, line) => {
+      const eqIndex = line.indexOf("=");
+      if (eqIndex === -1) {
+        return acc;
+      }
+      const key = line.slice(0, eqIndex).trim();
+      let value = line.slice(eqIndex + 1).trim();
+      if (
+        (value.startsWith("\"") && value.endsWith("\"")) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      acc[key] = value;
+      return acc;
+    }, {});
+}
+
+function loadEnvValues() {
+  const values = {};
+
+  if (process.env.SUPABASE_URL) {
+    values.SUPABASE_URL = process.env.SUPABASE_URL;
+  }
+  if (process.env.SUPABASE_ANON_KEY) {
+    values.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+  }
+
+  if ((!values.SUPABASE_URL || !values.SUPABASE_ANON_KEY) && fs.existsSync(ENV_FILE_PATH)) {
+    const fileEnv = parseEnv(fs.readFileSync(ENV_FILE_PATH, "utf8"));
+    values.SUPABASE_URL = values.SUPABASE_URL || fileEnv.SUPABASE_URL;
+    values.SUPABASE_ANON_KEY = values.SUPABASE_ANON_KEY || fileEnv.SUPABASE_ANON_KEY;
+  }
+
+  return values;
+}
+
+function validate(values) {
+  const missing = Object.entries({
+    SUPABASE_URL: values.SUPABASE_URL,
+    SUPABASE_ANON_KEY: values.SUPABASE_ANON_KEY,
+  })
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}. ` +
+        "Provide them via process.env or a .env file."
+    );
+  }
+}
+
+function build() {
+  const envValues = loadEnvValues();
+  validate(envValues);
+
+  const output = `window.__APP_ENV__ = Object.freeze({\n  SUPABASE_URL: ${JSON.stringify(
+    envValues.SUPABASE_URL
+  )},\n  SUPABASE_ANON_KEY: ${JSON.stringify(envValues.SUPABASE_ANON_KEY)}\n});\n`;
+
+  fs.writeFileSync(ENV_OUTPUT_PATH, output, "utf8");
+  console.log(`Environment file generated at ${ENV_OUTPUT_PATH}`);
+}
+
+try {
+  build();
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- ignore sensitive runtime files and add an example `.env` template
- update the configuration bootstrap to read Supabase credentials from a generated environment bundle
- add a build script and documentation so developers can inject runtime keys without committing them

## Testing
- SUPABASE_URL=https://example.supabase.co/rest/v1 SUPABASE_ANON_KEY=anon npm run build:env

------
https://chatgpt.com/codex/tasks/task_e_68deebcf39fc832b886fed2ff06c1c36