### PR TITLE
Add CSV import workflow for artikelen

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -238,6 +238,41 @@
             </div>
             <div id="articleList" class="article-list"></div>
             <button type="button" class="btn ghost" id="btnAddArticle">Artikel toevoegen</button>
+            <section class="article-import" aria-label="Artikelen importeren">
+              <div class="article-import__intro">
+                <h5 class="article-import__title">CSV-import</h5>
+                <p class="muted small">
+                  Upload een CSV-bestand met de kolommen “artikel”, “serienummer” en “aantal”.
+                  Controleer de preview voordat je de regels toevoegt.
+                </p>
+              </div>
+              <div class="article-import__actions">
+                <label class="article-import__file">
+                  <input type="file" id="articleCsvInput" accept=".csv,text/csv" aria-label="CSV-bestand voor artikelen" />
+                </label>
+                <button type="button" class="btn ghost small" id="btnClearArticleImport" disabled>Bestand wissen</button>
+              </div>
+              <div id="articleImportStatus" class="status"></div>
+              <div id="articleImportPreview" class="article-import-preview is-hidden" aria-live="polite">
+                <div class="table-wrap">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th scope="col">Rij</th>
+                        <th scope="col">Artikel</th>
+                        <th scope="col">Serienummer</th>
+                        <th scope="col">Aantal</th>
+                        <th scope="col">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody id="articleImportPreviewBody"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="article-import__actions">
+                <button type="button" class="btn primary" id="btnApplyArticleImport" disabled>Toevoegen</button>
+              </div>
+            </section>
           </div>
           <aside class="form-panel form-panel-secondary">
             <h5 class="panel-title">Voorbeeld</h5>

--- a/styles.css
+++ b/styles.css
@@ -477,6 +477,58 @@ h4 {
   box-shadow: var(--shadow-sm);
 }
 
+.article-import {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+  padding: 16px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+}
+
+.article-import__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.article-import__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.article-import__file input[type="file"] {
+  max-width: 100%;
+}
+
+.article-import-preview .table-wrap {
+  box-shadow: none;
+}
+
+.article-import-preview table tr.is-invalid {
+  background: #fff4f5;
+}
+
+.article-import-preview table tr.is-invalid th,
+.article-import-preview table tr.is-invalid td {
+  border-bottom-color: #f3cbd4;
+  color: var(--color-error);
+}
+
+.article-import-preview table tr.is-invalid td:last-child {
+  font-weight: 600;
+}
+
+.article-import-preview table tr td:last-child,
+.article-import-preview table tr th:last-child {
+  width: 30%;
+}
+
 .article-row .article-row-actions {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- add a CSV import panel to the artikelen stap with upload, preview and apply controls
- implement client-side CSV parsing, validation and bulk insertion of valid rows into the artikelenlijst
- style the preview table and highlight invalid regels in red for quick feedback

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deed0c11fc832bb71fb6d8965d3590