### PR TITLE
Fix drop policy syntax in transport SQL

### DIFF
--- a/supabase_transport.sql
+++ b/supabase_transport.sql
@@ -240,8 +240,8 @@ create or replace trigger transport_orders_set_updated_at
 
 alter table public.transport_orders enable row level security;
 
-alter table public.transport_orders drop policy if exists "allow anon read transport_orders";
-alter table public.transport_orders drop policy if exists "allow anon modify transport_orders";
+drop policy if exists "allow anon read transport_orders" on public.transport_orders;
+drop policy if exists "allow anon modify transport_orders" on public.transport_orders;
 
 do $$
 begin


### PR DESCRIPTION
## Summary
- correct the syntax used to drop row level security policies in the transport SQL script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df73db366c832b9532f147affadf01