### PR TITLE
Fix transport policy existence checks

### DIFF
--- a/supabase_transport.sql
+++ b/supabase_transport.sql
@@ -150,41 +150,41 @@ do $$
 begin
   if to_regclass('public.transport_trucks') is not null then
     execute 'alter table public.transport_trucks enable row level security';
-    execute 'alter table public.transport_trucks drop policy if exists "allow anon read transport_trucks"';
-    execute 'alter table public.transport_trucks drop policy if exists "allow anon modify transport_trucks"';
+    execute 'drop policy if exists "allow anon read transport_trucks" on public.transport_trucks';
+    execute 'drop policy if exists "allow anon modify transport_trucks" on public.transport_trucks';
 
     if not exists (
       select 1 from pg_policies
-      where schemaname = ''public''
-        and tablename = ''transport_trucks''
-        and policyname = ''transport_trucks_select_by_role''
+      where schemaname = 'public'
+        and tablename = 'transport_trucks'
+        and policyname = 'transport_trucks_select_by_role'
     ) then
       execute ''create policy transport_trucks_select_by_role on public.transport_trucks for select using (public.current_app_role() in (''''admin'''',''''planner'''',''''werknemer''''))'';
     end if;
 
     if not exists (
       select 1 from pg_policies
-      where schemaname = ''public''
-        and tablename = ''transport_trucks''
-        and policyname = ''transport_trucks_insert_by_planner''
+      where schemaname = 'public'
+        and tablename = 'transport_trucks'
+        and policyname = 'transport_trucks_insert_by_planner'
     ) then
       execute ''create policy transport_trucks_insert_by_planner on public.transport_trucks for insert with check (public.current_app_role() in (''''admin'''',''''planner''''))'';
     end if;
 
     if not exists (
       select 1 from pg_policies
-      where schemaname = ''public''
-        and tablename = ''transport_trucks''
-        and policyname = ''transport_trucks_update_by_planner''
+      where schemaname = 'public'
+        and tablename = 'transport_trucks'
+        and policyname = 'transport_trucks_update_by_planner'
     ) then
       execute ''create policy transport_trucks_update_by_planner on public.transport_trucks for update using (public.current_app_role() in (''''admin'''',''''planner'''')) with check (public.current_app_role() in (''''admin'''',''''planner''''))'';
     end if;
 
     if not exists (
       select 1 from pg_policies
-      where schemaname = ''public''
-        and tablename = ''transport_trucks''
-        and policyname = ''transport_trucks_delete_by_admin''
+      where schemaname = 'public'
+        and tablename = 'transport_trucks'
+        and policyname = 'transport_trucks_delete_by_admin'
     ) then
       execute ''create policy transport_trucks_delete_by_admin on public.transport_trucks for delete using (public.current_app_role() = ''''admin'''')'';
     end if;
@@ -240,8 +240,8 @@ create or replace trigger transport_orders_set_updated_at
 
 alter table public.transport_orders enable row level security;
 
-alter table public.transport_orders drop policy if exists "allow anon read transport_orders";
-alter table public.transport_orders drop policy if exists "allow anon modify transport_orders";
+drop policy if exists "allow anon read transport_orders" on public.transport_orders;
+drop policy if exists "allow anon modify transport_orders" on public.transport_orders;
 
 do $$
 begin
@@ -329,8 +329,8 @@ create index if not exists transport_lines_order_id_idx
 
 alter table public.transport_lines enable row level security;
 
-alter table public.transport_lines drop policy if exists "allow anon read transport_lines";
-alter table public.transport_lines drop policy if exists "allow anon modify transport_lines";
+drop policy if exists "allow anon read transport_lines" on public.transport_lines;
+drop policy if exists "allow anon modify transport_lines" on public.transport_lines;
 
 do $$
 begin
@@ -408,8 +408,8 @@ create index if not exists carriers_active_idx
 
 alter table public.carriers enable row level security;
 
-alter table public.carriers drop policy if exists "allow anon read carriers";
-alter table public.carriers drop policy if exists "allow anon modify carriers";
+drop policy if exists "allow anon read carriers" on public.carriers;
+drop policy if exists "allow anon modify carriers" on public.carriers;
 
 do $$
 begin


### PR DESCRIPTION
## Summary
- use the correct PostgreSQL `DROP POLICY` syntax for transport truck cleanup in the RLS migration
- update the transport lines and carriers sections to match the `DROP POLICY ... ON` form
- fix the policy existence checks to use proper literal quoting for transport_trucks policies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df73db366c832b9532f147affadf01