### PR TITLE
Add client-side validation for create user form

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -392,6 +392,14 @@ function createFormValidator(form, schema, registerListener) {
   };
 }
 
+window.FormValidation = Object.assign({}, window.FormValidation, {
+  createValidator: (form, schema, registerListener) =>
+    createFormValidator(form, schema, registerListener),
+  setFieldError,
+  clearFieldError,
+  classes: VALIDATION_CLASSES,
+});
+
 function refreshElements() {
   const doc = document;
   const ordersTableElement = doc.getElementById("ordersTable");


### PR DESCRIPTION
## Summary
- expose the shared form validation helpers from the main app bundle
- add inline client-side validation to the create user form with Motrac email checks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfa7509764832ba945c3110523962b