### PR TITLE
Add wizard progress feedback and disable next until valid

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -6,6 +6,20 @@
     </div>
     <form id="orderForm" class="form-sections wizard-form" novalidate>
       <nav class="wizard-stepper" aria-label="Stappen voor nieuwe aanvraag">
+        <div class="wizard-progress" aria-live="polite">
+          <div class="wizard-progress__label" id="wizardProgressLabel">Stap 1 van 5</div>
+          <div
+            class="wizard-progress__track"
+            id="wizardProgressTrack"
+            role="progressbar"
+            aria-valuemin="1"
+            aria-valuemax="5"
+            aria-valuenow="1"
+            aria-labelledby="wizardProgressLabel"
+          >
+            <div class="wizard-progress__indicator" id="wizardProgressIndicator"></div>
+          </div>
+        </div>
         <ol class="stepper">
           <li class="stepper-item is-current" data-stepper-step="1">
             <span class="stepper-index">1</span>

--- a/styles.css
+++ b/styles.css
@@ -614,6 +614,35 @@ h4 {
   margin-bottom: 24px;
 }
 
+.wizard-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.wizard-progress__label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.wizard-progress__track {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-border);
+  overflow: hidden;
+}
+
+.wizard-progress__indicator {
+  height: 100%;
+  width: 0%;
+  background: var(--color-primary);
+  border-radius: inherit;
+  transition: width 0.25s ease;
+}
+
 .stepper {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a visual progress indicator above the aanvraag wizard
- disable wizard navigation until required fields and article data validate successfully
- observe form changes so the next buttons and article actions stay in sync with user input

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfab492488832bbf55a99f6b60c012