### PR TITLE
Enable truck editing and clarify planning capacity feedback

### DIFF
--- a/partials/vloot.html
+++ b/partials/vloot.html
@@ -35,10 +35,28 @@
         <input id="truckDriver" placeholder="Naam chauffeur" />
       </label>
       <label>Stops per dag
-        <input id="truckCapacity" type="number" min="1" value="6" />
+        <input id="truckCapacity" type="number" min="1" value="6" data-default-value="6" />
       </label>
     </div>
-    <button id="btnAddTruck" class="btn">Vrachtwagen opslaan</button>
+    <div class="truck-form-actions">
+      <button
+        id="btnAddTruck"
+        class="btn"
+        type="button"
+        data-default-label="Vrachtwagen opslaan"
+        data-edit-label="Wijzigingen opslaan"
+      >
+        Vrachtwagen opslaan
+      </button>
+      <button
+        id="btnCancelTruckEdit"
+        class="btn ghost"
+        type="button"
+        hidden
+      >
+        Bewerken annuleren
+      </button>
+    </div>
     <div id="truckStatus" class="status"></div>
     <ul id="truckList" class="truck-list"></ul>
   </section>

--- a/styles.css
+++ b/styles.css
@@ -1417,6 +1417,14 @@ dialog::backdrop {
   gap: 12px;
 }
 
+.truck-form-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 12px;
+}
+
 .truck-list li {
   padding: 14px;
   border: 1px solid var(--color-border);
@@ -1428,11 +1436,26 @@ dialog::backdrop {
   box-shadow: var(--shadow-sm);
 }
 
+.truck-list li.is-editing {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(226, 0, 26, 0.15);
+}
+
+.truck-list li.is-editing strong {
+  color: var(--color-primary);
+}
+
 .truck-list li header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+}
+
+.truck-actions {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .truck-meta {


### PR DESCRIPTION
## Summary
- add edit and cancel controls for trucks on the fleet management page and sync renamed assignments back to orders
- highlight the active truck being edited and surface success messaging for edits and removals
- clarify the planning board error shown when a truck would exceed its stop limit during drag-and-drop

## Testing
- not run (ui change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfba859328832b8371c2b7d42db796