### PR TITLE
Fix carrier management UI and restore editing

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -543,6 +543,7 @@ const Carriers = {
   list: () => sbSelect("carriers", "?order=name.asc"),
   create: (c) => sbInsert("carriers", [c]).then(r => r[0]),
   update: (id, patch) => sbUpdate("carriers", `id=eq.${id}`, patch),
+  remove: (id) => sbDelete("carriers", `id=eq.${id}`),
 };
 
 const Users = {

--- a/partials/vloot.html
+++ b/partials/vloot.html
@@ -7,16 +7,35 @@
         <input id="quickCarrier" placeholder="Bijv. Beekman Transport" />
       </label>
       <label>Capaciteit/dag
-        <input id="quickCapacity" type="number" min="1" value="8" />
+        <input id="quickCapacity" type="number" min="1" value="8" data-default-value="8" />
       </label>
       <label>Basisregio
-        <select id="quickRegion">
+        <select id="quickRegion" data-default-value="Noord">
           <option>Noord</option><option>Midden</option><option>Zuid</option><option>België</option>
         </select>
       </label>
     </div>
-    <button id="btnAddCarrier" class="btn">Carrier toevoegen</button>
+    <div class="carrier-form-actions">
+      <button
+        id="btnAddCarrier"
+        class="btn"
+        type="button"
+        data-default-label="Carrier toevoegen"
+        data-edit-label="Wijzigingen opslaan"
+      >
+        Carrier toevoegen
+      </button>
+      <button
+        id="btnCancelCarrierEdit"
+        class="btn ghost"
+        type="button"
+        hidden
+      >
+        Bewerken annuleren
+      </button>
+    </div>
     <div id="carrierStatus" class="status"></div>
+    <ul id="carrierManageList" class="carrier-list"></ul>
   </section>
 
   <section class="card">

--- a/styles.css
+++ b/styles.css
@@ -1408,6 +1408,7 @@ dialog::backdrop {
   margin-top: 12px;
 }
 
+.carrier-list,
 .truck-list {
   list-style: none;
   padding: 0;
@@ -1417,6 +1418,7 @@ dialog::backdrop {
   gap: 12px;
 }
 
+.carrier-form-actions,
 .truck-form-actions {
   display: flex;
   gap: 8px;
@@ -1425,6 +1427,7 @@ dialog::backdrop {
   margin-top: 12px;
 }
 
+.carrier-list li,
 .truck-list li {
   padding: 14px;
   border: 1px solid var(--color-border);
@@ -1436,15 +1439,18 @@ dialog::backdrop {
   box-shadow: var(--shadow-sm);
 }
 
+.carrier-list li.is-editing,
 .truck-list li.is-editing {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(226, 0, 26, 0.15);
 }
 
+.carrier-list li.is-editing strong,
 .truck-list li.is-editing strong {
   color: var(--color-primary);
 }
 
+.carrier-list li header,
 .truck-list li header {
   display: flex;
   justify-content: space-between;
@@ -1452,12 +1458,14 @@ dialog::backdrop {
   gap: 12px;
 }
 
+.carrier-actions,
 .truck-actions {
   display: inline-flex;
   gap: 8px;
   flex-wrap: wrap;
 }
 
+.carrier-meta,
 .truck-meta {
   font-size: 12px;
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- replace the broken carriers table with a list-based manager that supports inline edit, cancel, and delete flows backed by Supabase
- add success messaging, delete confirmations, and automatic datalist refresh after carrier create, update, or removal
- align carrier management layout and styling with the existing truck controls for a consistent fleet UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfbe4280ac832bb3da5c1ad338fd6b