### PR TITLE
Improve accessibility contrast and buttons

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4679,6 +4679,26 @@ async function createOrder(){
   }
 }
 
+function getButtonLabel(button) {
+  if (!button) {
+    return "";
+  }
+  const label = button.querySelector(".btn__label");
+  return label?.textContent?.trim() || button.textContent?.trim() || "";
+}
+
+function setButtonLabel(button, text) {
+  if (!button) {
+    return;
+  }
+  const label = button.querySelector(".btn__label");
+  if (label) {
+    label.textContent = text;
+  } else {
+    button.textContent = text;
+  }
+}
+
 function ensureCarrierFormLabels() {
   const button = els?.btnAddCarrier;
   if (!button) {
@@ -4691,7 +4711,7 @@ function ensureCarrierFormLabels() {
     const datasetDefault = button.dataset?.defaultLabel;
     CARRIER_FORM_DEFAULT_LABEL = datasetDefault && datasetDefault.length
       ? datasetDefault
-      : button.textContent?.trim() || "Carrier toevoegen";
+      : getButtonLabel(button) || "Carrier toevoegen";
   }
   if (!CARRIER_FORM_EDIT_LABEL) {
     const datasetEdit = button.dataset?.editLabel;
@@ -4711,11 +4731,11 @@ function setCarrierFormMode(mode) {
   const { defaultLabel, editLabel } = ensureCarrierFormLabels();
   if (button) {
     if (mode === "edit") {
-      button.textContent = editLabel;
+      setButtonLabel(button, editLabel);
       button.classList.add("primary");
       button.dataset.mode = "edit";
     } else {
-      button.textContent = defaultLabel;
+      setButtonLabel(button, defaultLabel);
       button.classList.remove("primary");
       button.dataset.mode = "create";
     }
@@ -4966,7 +4986,7 @@ function ensureTruckFormLabels(){
     const datasetDefault = button.dataset?.defaultLabel;
     TRUCK_FORM_DEFAULT_LABEL = datasetDefault && datasetDefault.length
       ? datasetDefault
-      : button.textContent?.trim() || "Vrachtwagen opslaan";
+      : getButtonLabel(button) || "Vrachtwagen opslaan";
   }
   if (!TRUCK_FORM_EDIT_LABEL){
     const datasetEdit = button.dataset?.editLabel;
@@ -4986,11 +5006,11 @@ function setTruckFormMode(mode){
   const { defaultLabel, editLabel } = ensureTruckFormLabels();
   if (button){
     if (mode === "edit"){
-      button.textContent = editLabel;
+      setButtonLabel(button, editLabel);
       button.classList.add("primary");
       button.dataset.mode = "edit";
     } else {
-      button.textContent = defaultLabel;
+      setButtonLabel(button, defaultLabel);
       button.classList.remove("primary");
       button.dataset.mode = "create";
     }

--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -157,12 +157,17 @@
         </div>
         <button
           type="button"
-          class="btn primary btn-with-icon"
+          class="btn primary btn--icon-leading"
           role="button"
           tabindex="0"
         >
-          <span class="btn-with-icon__symbol" aria-hidden="true">+</span>
-          Laadlocatie toevoegen
+          <span class="btn__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 5v14" />
+              <path d="M5 12h14" />
+            </svg>
+          </span>
+          <span class="btn__label">Laadlocatie toevoegen</span>
         </button>
         <div class="wizard-actions">
           <button type="button" class="btn ghost" data-action="wizard-prev">Vorige</button>
@@ -219,12 +224,17 @@
         </div>
         <button
           type="button"
-          class="btn primary btn-with-icon"
+          class="btn primary btn--icon-leading"
           role="button"
           tabindex="0"
         >
-          <span class="btn-with-icon__symbol" aria-hidden="true">+</span>
-          Losadres toevoegen
+          <span class="btn__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 5v14" />
+              <path d="M5 12h14" />
+            </svg>
+          </span>
+          <span class="btn__label">Losadres toevoegen</span>
         </button>
         <div class="wizard-actions">
           <button type="button" class="btn ghost" data-action="wizard-prev">Vorige</button>
@@ -251,7 +261,15 @@
               </div>
             </div>
             <div id="articleList" class="article-list"></div>
-            <button type="button" class="btn ghost" id="btnAddArticle">Artikel toevoegen</button>
+            <button type="button" class="btn ghost btn--icon-leading" id="btnAddArticle">
+              <span class="btn__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 5v14" />
+                  <path d="M5 12h14" />
+                </svg>
+              </span>
+              <span class="btn__label">Artikel toevoegen</span>
+            </button>
             <section class="article-import" aria-label="Artikelen importeren">
               <div class="article-import__intro">
                 <h5 class="article-import__title">CSV-import</h5>
@@ -284,7 +302,15 @@
                 </div>
               </div>
               <div class="article-import__actions">
-                <button type="button" class="btn primary" id="btnApplyArticleImport" disabled>Toevoegen</button>
+                <button type="button" class="btn primary btn--icon-leading" id="btnApplyArticleImport" disabled>
+                  <span class="btn__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M12 5v14" />
+                      <path d="M5 12h14" />
+                    </svg>
+                  </span>
+                  <span class="btn__label">Toevoegen</span>
+                </button>
               </div>
             </section>
           </div>

--- a/partials/vloot.html
+++ b/partials/vloot.html
@@ -18,12 +18,18 @@
     <div class="carrier-form-actions">
       <button
         id="btnAddCarrier"
-        class="btn"
+        class="btn btn--icon-leading"
         type="button"
         data-default-label="Carrier toevoegen"
         data-edit-label="Wijzigingen opslaan"
       >
-        Carrier toevoegen
+        <span class="btn__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+        </span>
+        <span class="btn__label">Carrier toevoegen</span>
       </button>
       <button
         id="btnCancelCarrierEdit"
@@ -60,12 +66,18 @@
     <div class="truck-form-actions">
       <button
         id="btnAddTruck"
-        class="btn"
+        class="btn btn--icon-leading"
         type="button"
         data-default-label="Vrachtwagen opslaan"
         data-edit-label="Wijzigingen opslaan"
       >
-        Vrachtwagen opslaan
+        <span class="btn__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+        </span>
+        <span class="btn__label">Vrachtwagen opslaan</span>
       </button>
       <button
         id="btnCancelTruckEdit"

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,8 @@
 :root {
-  --color-primary: #E2001A;
+  --color-primary: #b00020;
+  --color-primary-strong: #8a0019;
+  --color-highlight-bg: #f3f4f6;
+  --color-highlight-border: #d0d5dd;
   --color-background: #F2F2F2;
   --color-surface: #FFFFFF;
   --color-text: #2B2B2B;
@@ -136,7 +139,7 @@ h4 {
   color: #ffffff;
   background: var(--color-primary);
   border-color: var(--color-primary);
-  box-shadow: 0 6px 18px rgba(226, 0, 26, 0.25);
+  box-shadow: 0 6px 18px rgba(176, 0, 32, 0.3);
 }
 
 .main-nav .nav-icon {
@@ -253,8 +256,10 @@ h4 {
 }
 
 .order-card {
-  background: #fdecee;
-  border-color: #f3cbd4;
+  background: var(--color-highlight-bg);
+  border-color: var(--color-highlight-border);
+  border-left: 4px solid var(--color-primary);
+  padding-left: 22px;
 }
 
 .order-card .bar h2 {
@@ -449,8 +454,8 @@ h4 {
 }
 
 .form-panel-secondary {
-  background: #fff4f5;
-  border-color: #f3cbd4;
+  background: var(--color-highlight-bg);
+  border-color: var(--color-highlight-border);
 }
 
 .panel-title {
@@ -511,12 +516,13 @@ h4 {
 }
 
 .article-import-preview table tr.is-invalid {
-  background: #fff4f5;
+  background: var(--color-highlight-bg);
+  border-left: 4px solid var(--color-error);
 }
 
 .article-import-preview table tr.is-invalid th,
 .article-import-preview table tr.is-invalid td {
-  border-bottom-color: #f3cbd4;
+  border-bottom-color: var(--color-highlight-border);
   color: var(--color-error);
 }
 
@@ -686,7 +692,8 @@ h4 {
 .stepper-item.is-current {
   border-color: var(--color-primary);
   color: var(--color-primary);
-  box-shadow: 0 0 0 1px rgba(226, 0, 26, 0.15);
+  background: var(--color-highlight-bg);
+  box-shadow: 0 0 0 2px rgba(176, 0, 32, 0.18);
 }
 
 .stepper-item.is-current .stepper-index,
@@ -696,8 +703,8 @@ h4 {
 }
 
 .stepper-item.is-complete {
-  border-color: rgba(226, 0, 26, 0.4);
-  background: rgba(226, 0, 26, 0.08);
+  border-color: rgba(176, 0, 32, 0.35);
+  background: var(--color-highlight-bg);
   color: var(--color-primary);
 }
 
@@ -723,6 +730,29 @@ h4 {
 
 .wizard-actions-final #createStatus {
   flex: 1 1 100%;
+}
+
+@media (max-width: 520px) {
+  .wizard-actions,
+  .wizard-actions-final {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .wizard-actions .btn,
+  .wizard-actions-final .btn {
+    width: 100%;
+  }
+
+  .stepper {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .stepper-item {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }
 
 .summary-grid {
@@ -917,7 +947,7 @@ textarea {
 .field-invalid select,
 .field-invalid textarea {
   border-color: var(--color-error);
-  box-shadow: 0 0 0 2px rgba(226, 0, 26, 0.15);
+  box-shadow: 0 0 0 2px rgba(198, 40, 40, 0.18);
 }
 
 .field-error {
@@ -931,7 +961,7 @@ input:focus,
 select:focus,
 textarea:focus {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(226, 0, 26, 0.15);
+  box-shadow: 0 0 0 3px rgba(176, 0, 32, 0.2);
 }
 
 textarea {
@@ -941,12 +971,15 @@ textarea {
 
 .btn {
   padding: 10px 18px;
+  min-height: 44px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-text);
   cursor: pointer;
   font-weight: 600;
+  line-height: 1.2;
+  text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
 }
 
@@ -970,7 +1003,7 @@ textarea {
 }
 
 .btn:focus-visible {
-  outline: 3px solid rgba(226, 0, 26, 0.35);
+  outline: 3px solid rgba(176, 0, 32, 0.4);
   outline-offset: 2px;
 }
 
@@ -982,8 +1015,8 @@ textarea {
 
 .btn.primary:hover,
 .btn.primary:focus-visible {
-  background: #b80017;
-  border-color: #b80017;
+  background: var(--color-primary-strong);
+  border-color: var(--color-primary-strong);
   color: #ffffff;
 }
 
@@ -991,36 +1024,49 @@ textarea {
   background: var(--color-background);
 }
 
-.btn.btn-with-icon {
+.btn--icon-leading {
   display: inline-flex;
   align-items: center;
   gap: 10px;
 }
 
-.btn.btn-with-icon .btn-with-icon__symbol {
+.btn__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 24px;
   height: 24px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.85);
-  background: rgba(255, 255, 255, 0.18);
-  font-size: 18px;
-  line-height: 1;
-  font-weight: 700;
-  transition: background 0.2s ease, color 0.2s ease;
+  border-radius: 6px;
+  background: rgba(43, 43, 43, 0.08);
+  color: inherit;
+  flex-shrink: 0;
 }
 
-.btn.primary.btn-with-icon:hover .btn-with-icon__symbol,
-.btn.primary.btn-with-icon:focus-visible .btn-with-icon__symbol {
+.btn__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.btn__label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.btn.primary .btn__icon {
+  background: rgba(255, 255, 255, 0.22);
+  color: #ffffff;
+}
+
+.btn.primary:hover .btn__icon,
+.btn.primary:focus-visible .btn__icon {
   background: #ffffff;
-  color: var(--color-primary);
+  color: var(--color-primary-strong);
 }
 
 .btn.small {
   padding: 6px 10px;
   font-size: 13px;
+  min-height: 36px;
 }
 
 .status {
@@ -1442,7 +1488,7 @@ dialog::backdrop {
 .carrier-list li.is-editing,
 .truck-list li.is-editing {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px rgba(226, 0, 26, 0.15);
+  box-shadow: 0 0 0 2px rgba(176, 0, 32, 0.18);
 }
 
 .carrier-list li.is-editing strong,
@@ -1541,7 +1587,7 @@ dialog::backdrop {
 }
 
 .plan-lane.lane-unplanned {
-  background: linear-gradient(180deg, rgba(226, 0, 26, 0.05), rgba(226, 0, 26, 0.02));
+  background: linear-gradient(180deg, rgba(243, 244, 246, 0.9), rgba(243, 244, 246, 0.7));
   border-style: dashed;
 }
 
@@ -1646,7 +1692,8 @@ dialog::backdrop {
 }
 
 .assignment.is-unplanned {
-  background: rgba(226, 0, 26, 0.04);
+  background: var(--color-highlight-bg);
+  border-color: var(--color-highlight-border);
 }
 
 .assignment.is-dragging {
@@ -1775,7 +1822,8 @@ dialog::backdrop {
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(226, 0, 26, 0.12);
+  background: var(--color-highlight-bg);
+  border: 1px solid rgba(176, 0, 32, 0.35);
   color: var(--color-primary);
   font-size: 11px;
   font-weight: 600;
@@ -1934,11 +1982,11 @@ dialog::backdrop {
 #ordersTable tbody tr.order-row:focus-visible {
   outline: 3px solid var(--color-focus-ring);
   outline-offset: 2px;
-  background: rgba(226, 0, 26, 0.08);
+  background: var(--color-highlight-bg);
 }
 
 #ordersTable tbody tr.order-row:hover {
-  background: rgba(226, 0, 26, 0.06);
+  background: var(--color-highlight-bg);
 }
 
 #ordersTable tbody tr.order-row.is-readonly-order {


### PR DESCRIPTION
## Summary
- update the global colour tokens and component styles to meet WCAG AA contrast requirements
- add responsive tweaks for the wizard controls so forms stack cleanly on small screens
- introduce reusable icon button styling and adjust carrier/article actions to keep accessible labels when state changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfcc85bac4832ba1e81577d987f7d7