### PR TITLE
Refactor orders layout with horizontal filters

### DIFF
--- a/partials/orders.html
+++ b/partials/orders.html
@@ -1,8 +1,8 @@
 <div class="page orders-page" data-route="orders" data-require-auth="true" data-title="Transportplanner — Orders">
-  <div class="wrap">
-    <aside class="sidebar">
-      <section class="card">
-        <h3>Filters</h3>
+  <div class="wrap orders-layout">
+    <section class="card filters-card">
+      <h3>Filters</h3>
+      <div class="filters-grid">
         <label>Regio
           <select id="filterRegion">
             <option value="">Alle</option>
@@ -35,42 +35,43 @@
         <label>Leverdatum
           <input id="filterDate" type="date" />
         </label>
+      </div>
+      <div class="filters-actions">
         <button id="btnApplyFilters" class="btn ghost">Toepassen</button>
         <button id="btnReload" class="btn">Vernieuwen</button>
-      </section>
-    </aside>
+      </div>
+    </section>
 
-    <section class="content">
-      <section class="card">
-        <div class="bar">
-          <h2>Orders</h2>
-          <div class="bar-actions">
-            <div class="muted small">Klik op een regel om details te bewerken.</div>
-            <div class="export-menu" data-export-menu>
-              <button
-                type="button"
-                id="btnExportOrders"
-                class="btn ghost export-menu__toggle"
-                aria-haspopup="menu"
-                aria-expanded="false"
-                aria-controls="ordersExportMenu"
-              >
-                Exporteer
-              </button>
-              <div
-                id="ordersExportMenu"
-                class="export-menu__panel"
-                data-export-menu-panel
-                role="menu"
-                hidden
-              >
-                <button type="button" class="export-menu__item" data-export-format="csv" role="menuitem">Download CSV</button>
-                <button type="button" class="export-menu__item" data-export-format="excel" role="menuitem">Download Excel</button>
-              </div>
+    <section class="card order-card orders-card">
+      <div class="bar">
+        <h2>Orders</h2>
+        <div class="bar-actions">
+          <div class="muted small">Klik op een regel om details te bewerken.</div>
+          <div class="export-menu" data-export-menu>
+            <button
+              type="button"
+              id="btnExportOrders"
+              class="btn ghost export-menu__toggle"
+              aria-haspopup="menu"
+              aria-expanded="false"
+              aria-controls="ordersExportMenu"
+            >
+              Exporteer
+            </button>
+            <div
+              id="ordersExportMenu"
+              class="export-menu__panel"
+              data-export-menu-panel
+              role="menu"
+              hidden
+            >
+              <button type="button" class="export-menu__item" data-export-format="csv" role="menuitem">Download CSV</button>
+              <button type="button" class="export-menu__item" data-export-format="excel" role="menuitem">Download Excel</button>
             </div>
           </div>
         </div>
-        <div class="table-wrap">
+      </div>
+      <div class="table-wrap">
           <table id="ordersTable">
             <thead>
               <tr>
@@ -90,19 +91,18 @@
             </tbody>
           </table>
         </div>
-        <nav class="pager is-hidden" id="ordersPager" aria-label="Paginering">
-          <button type="button" class="btn ghost" id="pagerPrev" aria-label="Vorige pagina">&laquo; Vorige</button>
-          <span id="pagerInfo" class="pager-info">Geen resultaten</span>
-          <button type="button" class="btn ghost" id="pagerNext" aria-label="Volgende pagina">Volgende &raquo;</button>
-          <label class="pager-size" for="pagerPageSize">Per pagina
-            <select id="pagerPageSize">
-              <option value="10">10</option>
-              <option value="20" selected>20</option>
-              <option value="50">50</option>
-            </select>
-          </label>
-        </nav>
-      </section>
+      <nav class="pager is-hidden" id="ordersPager" aria-label="Paginering">
+        <button type="button" class="btn ghost" id="pagerPrev" aria-label="Vorige pagina">&laquo; Vorige</button>
+        <span id="pagerInfo" class="pager-info">Geen resultaten</span>
+        <button type="button" class="btn ghost" id="pagerNext" aria-label="Volgende pagina">Volgende &raquo;</button>
+        <label class="pager-size" for="pagerPageSize">Per pagina
+          <select id="pagerPageSize">
+            <option value="10">10</option>
+            <option value="20" selected>20</option>
+            <option value="50">50</option>
+          </select>
+        </label>
+      </nav>
     </section>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,7 @@ h4 {
   margin-left: 4px;
 }
 
+
 .wrap {
   display: grid;
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
@@ -195,6 +196,48 @@ h4 {
   max-width: 1180px;
   margin: 0 auto;
   padding: 24px 20px 48px;
+}
+
+.wrap.orders-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.orders-page .filters-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.orders-page .filters-grid {
+  display: grid;
+  gap: 12px 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.orders-page .filters-card label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--color-muted);
+}
+
+.orders-page .filters-card input,
+.orders-page .filters-card select {
+  width: 100%;
+  min-height: 38px;
+}
+
+.orders-page .filters-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.orders-page .filters-actions .btn {
+  flex: 0 0 auto;
 }
 
 @media (max-width: 980px) {
@@ -364,6 +407,19 @@ h4 {
   .plan-controls select {
     width: 100%;
     min-width: 0;
+  }
+
+  .orders-page .filters-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .orders-page .filters-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .orders-page .filters-actions .btn {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the orders page sidebar with a horizontal filter panel above the results
- adjust the orders markup to align with the new stacked layout and keep existing behaviour
- add responsive styling so the filter grid wraps cleanly on smaller screens

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68dfd7b75588832bb8b05c12e6a3541b