### PR TITLE
Add PDF document export and mailing capabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 # Copy this file to .env and fill in the values for your Supabase project.
 SUPABASE_URL="https://your-project-id.supabase.co/rest/v1"
 SUPABASE_ANON_KEY="your-anon-key"
+
+# Optional: enable automatic e-mail notifications for new/updated orders.
+# EMAIL_NOTIFICATIONS_URL="https://notifications.example.com/hooks/order"
+# EMAIL_NOTIFICATIONS_FROM="planner@example.com"
+# EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS="logistics@example.com,planning@example.com"
+
+# Optional: override the default document mail templates and distribution lists.
+# Provide JSON arrays with the structure documented in README.md.
+# DOCUMENT_EMAIL_TEMPLATES='[{"id":"rittenlijst","name":"Dagplanning","type":"rittenlijst","subject":"Rittenlijst {date}","body":"..."}]'
+# DOCUMENT_EMAIL_LISTS='[{"id":"planning","name":"Planningsteam","recipients":["planning@example.com"],"cc":["expeditie@example.com"]}]'

--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS=logistiek@example.com,planning@example.co
 ```
 
 Alle velden zijn optioneel. Zonder `EMAIL_NOTIFICATIONS_URL` blijven e-mailnotificaties uitgeschakeld. De standaardontvangers worden gecombineerd met het e-mailadres van de klant op de order.
+
+### Documentmailing configureren
+
+De module voor rittenlijsten en CMR's gebruikt sjablonen en distributielijsten. Deze zijn standaard aanwezig, maar kunnen via JSON-configuratie in `.env` worden aangepast:
+
+```
+DOCUMENT_EMAIL_TEMPLATES='[
+  {"id":"rittenlijst","name":"Dagplanning","type":"rittenlijst","subject":"Rittenlijst {date}","body":"..."},
+  {"id":"cmr","name":"CMR","type":"cmr","subject":"CMR {reference}","body":"..."}
+]'
+DOCUMENT_EMAIL_LISTS='[
+  {"id":"planning","name":"Planningsteam","recipients":["planning@example.com"]},
+  {"id":"expeditie","name":"Expeditie","recipients":["expeditie@example.com"],"cc":["magazijn@example.com"]}
+]'
+```
+
+Laat velden leeg of weg om te vallen op de ingebouwde standaards.

--- a/index.html
+++ b/index.html
@@ -141,6 +141,36 @@
 
   <main id="appRoot" aria-live="polite" aria-busy="true"></main>
 
+  <dialog id="documentMailDialog" class="document-mail-dialog">
+    <form method="dialog" class="card document-mail" id="documentMailForm">
+      <header class="document-mail__header">
+        <h3 id="documentMailTitle">Document mailen</h3>
+        <p class="muted small" id="documentMailDescription"></p>
+      </header>
+      <label class="document-mail__field">Template
+        <select id="documentMailTemplate"></select>
+      </label>
+      <label class="document-mail__field">Distributielijst
+        <select id="documentMailList"></select>
+      </label>
+      <p class="muted small" id="documentMailListInfo"></p>
+      <label class="document-mail__field">Onderwerp
+        <input type="text" id="documentMailSubject" />
+      </label>
+      <label class="document-mail__field">Bericht
+        <textarea id="documentMailBody" rows="6"></textarea>
+      </label>
+      <label class="document-mail__field">Aanvullende ontvangers
+        <input type="text" id="documentMailAdditional" placeholder="Bijv. chauffeur@example.com, expeditie@example.com" />
+      </label>
+      <div class="document-mail__status" id="documentMailStatus" role="status"></div>
+      <menu class="menu document-mail__actions">
+        <button value="cancel" class="btn ghost">Annuleren</button>
+        <button id="documentMailSubmit" value="default" class="btn primary">Versturen</button>
+      </menu>
+    </form>
+  </dialog>
+
   <script src="js/date-utils.js"></script>
   <script>
     window.__APP_ENV__ = Object.assign(
@@ -158,6 +188,8 @@
   <script src="js/api.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/toast.js"></script>
+  <script src="js/documents.js"></script>
+  <script src="js/document-mail.js"></script>
   <script src="js/app.js"></script>
   <script src="js/theme-toggle.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>

--- a/js/config.js
+++ b/js/config.js
@@ -17,6 +17,84 @@
     return [];
   };
 
+  const parseJson = (value) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    if (typeof value === "object") {
+      return value;
+    }
+    if (typeof value !== "string") {
+      return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      console.warn("Kan JSON-configuratie niet parsen", error);
+      return null;
+    }
+  };
+
+  const normalizeTemplate = (template) => {
+    if (!template || typeof template !== "object") {
+      return null;
+    }
+    const id = toStringValue(template.id) || toStringValue(template.name) || toStringValue(template.subject);
+    if (!id) {
+      return null;
+    }
+    return Object.freeze({
+      id,
+      name: toStringValue(template.name) || id,
+      type: toStringValue(template.type) || "",
+      subject: toStringValue(template.subject) || "",
+      body: toStringValue(template.body) || "",
+    });
+  };
+
+  const normalizeList = (list, fallbackRecipients = []) => {
+    if (!list || typeof list !== "object") {
+      return null;
+    }
+    const id = toStringValue(list.id) || toStringValue(list.name);
+    if (!id) {
+      return null;
+    }
+    const recipients = parseList(list.recipients);
+    const cc = parseList(list.cc);
+    const bcc = parseList(list.bcc);
+    return Object.freeze({
+      id,
+      name: toStringValue(list.name) || id,
+      recipients: recipients.length ? recipients : fallbackRecipients.slice(),
+      cc,
+      bcc,
+    });
+  };
+
+  const defaultTemplates = Object.freeze([
+    Object.freeze({
+      id: "rittenlijst",
+      name: "Rittenlijst dagplanning",
+      type: "rittenlijst",
+      subject: "Rittenlijst {date}",
+      body:
+        "Beste team,\n\nIn de bijlage vind je de rittenlijst voor {date}.\nRoutes: {routeCount}, stops: {stopCount}.\n\nMet vriendelijke groet,\nTransportplanning",
+    }),
+    Object.freeze({
+      id: "cmr",
+      name: "CMR versturen",
+      type: "cmr",
+      subject: "CMR {reference}",
+      body:
+        "Beste relatie,\n\nIn de bijlage vind je de CMR voor {reference}.\nGeplande datum: {plannedDate}.\n\nMet vriendelijke groet,\nTransportplanning",
+    }),
+  ]);
+
   const config = {
     SUPABASE_URL: toStringValue(sourceEnv.SUPABASE_URL),
     SUPABASE_ANON_KEY: toStringValue(sourceEnv.SUPABASE_ANON_KEY),
@@ -28,6 +106,8 @@
     EMAIL_NOTIFICATIONS_ENABLED_EVENTS: Object.freeze(
       parseList(sourceEnv.EMAIL_NOTIFICATIONS_ENABLED_EVENTS)
     ),
+    DOCUMENT_EMAIL_TEMPLATES: Object.freeze([]),
+    DOCUMENT_EMAIL_LISTS: Object.freeze([]),
   };
 
   const missing = Object.entries(config)
@@ -56,6 +136,51 @@
       "updated",
       "cancelled",
     ]);
+  }
+
+  const templateConfig = parseJson(sourceEnv.DOCUMENT_EMAIL_TEMPLATES);
+  if (Array.isArray(templateConfig)) {
+    const normalized = templateConfig.map(normalizeTemplate).filter(Boolean);
+    if (normalized.length) {
+      config.DOCUMENT_EMAIL_TEMPLATES = Object.freeze(normalized);
+    } else {
+      config.DOCUMENT_EMAIL_TEMPLATES = defaultTemplates;
+    }
+  } else {
+    config.DOCUMENT_EMAIL_TEMPLATES = defaultTemplates;
+  }
+
+  const listConfig = parseJson(sourceEnv.DOCUMENT_EMAIL_LISTS);
+  const baseRecipients = Array.isArray(config.EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS)
+    ? config.EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS
+    : [];
+  if (Array.isArray(listConfig)) {
+    const normalizedLists = listConfig
+      .map((item) => normalizeList(item, baseRecipients))
+      .filter(Boolean);
+    if (normalizedLists.length) {
+      config.DOCUMENT_EMAIL_LISTS = Object.freeze(normalizedLists);
+    } else {
+      config.DOCUMENT_EMAIL_LISTS = Object.freeze([
+        normalizeList({ id: "planning", name: "Planningsteam" }, baseRecipients),
+      ]);
+    }
+  } else {
+    const planningList = normalizeList(
+      { id: "planning", name: "Planningsteam" },
+      baseRecipients
+    );
+    const expeditionList = normalizeList(
+      {
+        id: "expeditie",
+        name: "Expeditie & magazijn",
+        recipients: [],
+      },
+      []
+    );
+    config.DOCUMENT_EMAIL_LISTS = Object.freeze(
+      [planningList, expeditionList].filter(Boolean)
+    );
   }
 
   window.APP_CONFIG = Object.freeze(config);

--- a/js/document-mail.js
+++ b/js/document-mail.js
@@ -1,0 +1,478 @@
+(function () {
+  const config = window.APP_CONFIG || {};
+  const templates = Array.isArray(config.DOCUMENT_EMAIL_TEMPLATES)
+    ? config.DOCUMENT_EMAIL_TEMPLATES
+    : [];
+  const lists = Array.isArray(config.DOCUMENT_EMAIL_LISTS)
+    ? config.DOCUMENT_EMAIL_LISTS
+    : [];
+
+  const dialog = document.getElementById("documentMailDialog");
+  const form = document.getElementById("documentMailForm");
+  if (!dialog || !form) {
+    window.DocumentMail = {
+      open() {
+        window.alert("E-mailmodule is niet beschikbaar in deze omgeving.");
+        return Promise.resolve({ ok: false, reason: "unavailable" });
+      },
+    };
+    return;
+  }
+
+  const els = {
+    title: document.getElementById("documentMailTitle"),
+    description: document.getElementById("documentMailDescription"),
+    template: document.getElementById("documentMailTemplate"),
+    list: document.getElementById("documentMailList"),
+    listInfo: document.getElementById("documentMailListInfo"),
+    subject: document.getElementById("documentMailSubject"),
+    body: document.getElementById("documentMailBody"),
+    additional: document.getElementById("documentMailAdditional"),
+    status: document.getElementById("documentMailStatus"),
+    submit: document.getElementById("documentMailSubmit"),
+  };
+
+  const state = {
+    resolver: null,
+    rejecter: null,
+    options: null,
+    result: null,
+    sending: false,
+  };
+
+  function sanitizeString(value) {
+    if (!value && value !== 0) return "";
+    return String(value).trim();
+  }
+
+  function normalizeEmail(value) {
+    const text = sanitizeString(value).toLowerCase();
+    if (!text || !text.includes("@")) {
+      return null;
+    }
+    return text;
+  }
+
+  function parseRecipients(value) {
+    if (!value) return [];
+    const parts = String(value)
+      .split(/[;,\n\s]+/)
+      .map((part) => normalizeEmail(part))
+      .filter(Boolean);
+    const unique = [];
+    const seen = new Set();
+    for (const email of parts) {
+      if (seen.has(email)) continue;
+      seen.add(email);
+      unique.push(email);
+    }
+    return unique;
+  }
+
+  function getTemplatesForType(type) {
+    const lowerType = type ? String(type).toLowerCase() : null;
+    return templates.filter((tpl) => {
+      if (!tpl || typeof tpl !== "object") {
+        return false;
+      }
+      if (!tpl.type) {
+        return true;
+      }
+      return String(tpl.type).toLowerCase() === lowerType;
+    });
+  }
+
+  function getTemplateById(id) {
+    const lookup = sanitizeString(id).toLowerCase();
+    return templates.find((tpl) => sanitizeString(tpl.id).toLowerCase() === lookup) || null;
+  }
+
+  function getListById(id) {
+    const lookup = sanitizeString(id).toLowerCase();
+    return lists.find((list) => sanitizeString(list.id).toLowerCase() === lookup) || null;
+  }
+
+  function buildTemplateOptions(type) {
+    const available = getTemplatesForType(type);
+    const options = available.length ? available : templates;
+    return Array.isArray(options) ? options : [];
+  }
+
+  function buildListOptions() {
+    return Array.isArray(lists) ? lists : [];
+  }
+
+  function fillSelect(select, items, getValue, getLabel) {
+    if (!select) return;
+    select.innerHTML = "";
+    if (!Array.isArray(items) || !items.length) {
+      const option = document.createElement("option");
+      option.value = "";
+      option.textContent = "Geen opties";
+      select.appendChild(option);
+      select.setAttribute("disabled", "disabled");
+      return;
+    }
+    select.removeAttribute("disabled");
+    for (const item of items) {
+      const option = document.createElement("option");
+      option.value = getValue(item);
+      option.textContent = getLabel(item);
+      select.appendChild(option);
+    }
+  }
+
+  function setStatus(message, variant = "") {
+    if (!els.status) return;
+    els.status.textContent = message || "";
+    els.status.classList.remove("is-error", "is-success");
+    if (variant === "error") {
+      els.status.classList.add("is-error");
+    } else if (variant === "success") {
+      els.status.classList.add("is-success");
+    }
+  }
+
+  function setDisabled(disabled) {
+    if (disabled) {
+      els.submit?.setAttribute("disabled", "disabled");
+      els.submit?.setAttribute("aria-disabled", "true");
+    } else {
+      els.submit?.removeAttribute("disabled");
+      els.submit?.removeAttribute("aria-disabled");
+    }
+  }
+
+  function formatListRecipients(list) {
+    if (!list || typeof list !== "object") {
+      return "Geen vaste ontvangers";
+    }
+    const recipients = Array.isArray(list.recipients) ? list.recipients : [];
+    if (!recipients.length) {
+      return "Geen vaste ontvangers";
+    }
+    return `Ontvangers: ${recipients.join(", ")}`;
+  }
+
+  function formatDescription(options) {
+    if (!options || typeof options !== "object") {
+      return "";
+    }
+    if (options.description) {
+      return options.description;
+    }
+    const type = sanitizeString(options.documentType).toLowerCase();
+    if (type === "rittenlijst") {
+      const dateLabel = sanitizeString(options.context?.dateLabel) || sanitizeString(options.context?.date);
+      return dateLabel ? `Rittenlijst voor ${dateLabel}` : "Rittenlijst versturen";
+    }
+    if (type === "cmr") {
+      const reference = sanitizeString(options.context?.reference);
+      const customer = sanitizeString(options.context?.customer);
+      const parts = [];
+      if (reference) parts.push(reference);
+      if (customer) parts.push(customer);
+      return parts.length ? `CMR voor ${parts.join(" — ")}` : "CMR versturen";
+    }
+    return "Document verzenden";
+  }
+
+  function fillTemplate(template, context = {}) {
+    if (!template || typeof template !== "object") {
+      return { subject: "", body: "" };
+    }
+    const replacements = {
+      date: sanitizeString(context.dateLabel || context.date || ""),
+      reference: sanitizeString(context.reference || ""),
+      customer: sanitizeString(context.customer || ""),
+      plannedDate: sanitizeString(context.plannedDate || ""),
+      deliveryDate: sanitizeString(context.deliveryDate || ""),
+      routeCount: sanitizeString(context.routeCount || ""),
+      stopCount: sanitizeString(context.stopCount || ""),
+      backlogCount: sanitizeString(context.backlogCount || ""),
+      generatedAt: sanitizeString(context.generatedAt || ""),
+    };
+
+    const replaceTokens = (text) => {
+      if (!text && text !== 0) return "";
+      return String(text).replace(/\{(\w+)\}/g, (match, key) => {
+        const normalized = key ? String(key).trim() : "";
+        if (!normalized) return match;
+        const value = replacements[normalized];
+        return value !== undefined && value !== null && value !== "" ? value : match;
+      });
+    };
+
+    return {
+      subject: replaceTokens(template.subject || ""),
+      body: replaceTokens(template.body || ""),
+    };
+  }
+
+  function uniqueRecipients(list, additional, override) {
+    const emails = new Set();
+    const combined = [];
+    const push = (value) => {
+      const normalized = normalizeEmail(value);
+      if (!normalized || emails.has(normalized)) return;
+      emails.add(normalized);
+      combined.push(normalized);
+    };
+    if (Array.isArray(list)) {
+      list.forEach(push);
+    }
+    if (Array.isArray(additional)) {
+      additional.forEach(push);
+    }
+    if (Array.isArray(override)) {
+      override.forEach(push);
+    }
+    return combined;
+  }
+
+  function blobToBase64(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = typeof reader.result === "string" ? reader.result : "";
+        const base64 = result.includes(",") ? result.split(",").pop() : result;
+        resolve(base64 || "");
+      };
+      reader.onerror = () => reject(reader.error || new Error("blob-read"));
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  async function prepareAttachments(options) {
+    if (!options || !Array.isArray(options.attachments)) {
+      return [];
+    }
+    const attachments = [];
+    for (const attachment of options.attachments) {
+      if (!attachment || !attachment.blob) continue;
+      const filename = sanitizeString(attachment.filename) || "document.pdf";
+      const type = sanitizeString(attachment.contentType) || attachment.blob.type || "application/pdf";
+      try {
+        const content = await blobToBase64(attachment.blob);
+        attachments.push({ filename, contentType: type, content });
+      } catch (error) {
+        console.warn("Kan bijlage niet converteren", error);
+      }
+    }
+    return attachments;
+  }
+
+  function resetStatus() {
+    setStatus("");
+    setDisabled(false);
+    state.sending = false;
+  }
+
+  function finish(result) {
+    state.result = result || { ok: false, reason: "cancelled" };
+    state.sending = false;
+    if (dialog.open) {
+      dialog.close();
+    } else if (state.resolver) {
+      const resolver = state.resolver;
+      state.resolver = null;
+      resolver(state.result);
+    }
+  }
+
+  function updateListInfo() {
+    if (!els.listInfo) return;
+    const current = getListById(els.list?.value);
+    els.listInfo.textContent = formatListRecipients(current);
+  }
+
+  function populateForm(options) {
+    const templateOptions = buildTemplateOptions(options.documentType);
+    fillSelect(
+      els.template,
+      templateOptions,
+      (item) => sanitizeString(item.id) || sanitizeString(item.name) || "template",
+      (item) => sanitizeString(item.name || item.label || item.subject || "Template")
+    );
+    const listOptions = buildListOptions();
+    fillSelect(
+      els.list,
+      listOptions,
+      (item) => sanitizeString(item.id) || sanitizeString(item.name) || "list",
+      (item) => sanitizeString(item.name || item.label || "Distributielijst")
+    );
+
+    const defaultTemplateId = options.defaultTemplateId || (templateOptions[0] && templateOptions[0].id) || "";
+    if (els.template) {
+      els.template.value = sanitizeString(defaultTemplateId);
+      if (!els.template.value && els.template.options.length) {
+        els.template.selectedIndex = 0;
+      }
+    }
+
+    const defaultListId = options.defaultListId || (listOptions[0] && listOptions[0].id) || "";
+    if (els.list) {
+      els.list.value = sanitizeString(defaultListId);
+      if (!els.list.value && els.list.options.length) {
+        els.list.selectedIndex = 0;
+      }
+    }
+
+    const selectedTemplate = getTemplateById(els.template?.value) || templateOptions[0] || null;
+    const templateFilled = fillTemplate(selectedTemplate, options.context || {});
+    if (els.subject) {
+      els.subject.value = templateFilled.subject || "";
+    }
+    if (els.body) {
+      els.body.value = templateFilled.body || "";
+    }
+    if (els.additional) {
+      const extra = Array.isArray(options.recipients)
+        ? options.recipients.join(", ")
+        : sanitizeString(options.recipients);
+      els.additional.value = extra || "";
+    }
+    if (els.title) {
+      els.title.textContent = sanitizeString(options.title) || "Document mailen";
+    }
+    if (els.description) {
+      els.description.textContent = formatDescription(options);
+    }
+    updateListInfo();
+    resetStatus();
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (state.sending) {
+      return;
+    }
+    if (!window.EmailNotifications || typeof window.EmailNotifications.sendDocumentMail !== "function") {
+      setStatus("E-mailservice is niet geconfigureerd.", "error");
+      return;
+    }
+
+    const selectedTemplate = getTemplateById(els.template?.value);
+    const selectedList = getListById(els.list?.value);
+    const subject = sanitizeString(els.subject?.value);
+    const message = sanitizeString(els.body?.value);
+    const additionalRecipients = parseRecipients(els.additional?.value);
+
+    if (!subject) {
+      setStatus("Onderwerp is verplicht.", "error");
+      return;
+    }
+    if (!message) {
+      setStatus("Berichttekst is verplicht.", "error");
+      return;
+    }
+
+    const baseRecipients = Array.isArray(selectedList?.recipients) ? selectedList.recipients : [];
+    const overrideRecipients = Array.isArray(state.options?.recipientsOverride)
+      ? state.options.recipientsOverride
+      : [];
+    const recipients = uniqueRecipients(baseRecipients, additionalRecipients, overrideRecipients);
+
+    if (!recipients.length) {
+      setStatus("Voeg minimaal één ontvanger toe.", "error");
+      return;
+    }
+
+    setStatus("Versturen…");
+    setDisabled(true);
+    state.sending = true;
+
+    try {
+      const attachments = await prepareAttachments(state.options || {});
+      const meta = {
+        templateId: selectedTemplate?.id || null,
+        listId: selectedList?.id || null,
+        documentType: state.options?.documentType || null,
+        context: state.options?.context || null,
+      };
+      const payload = {
+        subject,
+        message,
+        recipients,
+        attachments,
+        includeDefaultRecipients: state.options?.includeDefaultRecipients ?? false,
+        cc: Array.isArray(selectedList?.cc) ? selectedList.cc : undefined,
+        bcc: Array.isArray(selectedList?.bcc) ? selectedList.bcc : undefined,
+        meta,
+      };
+      const result = await window.EmailNotifications.sendDocumentMail(payload);
+      if (!result || result.ok !== true) {
+        const reason = result?.reason || "request-failed";
+        if (reason === "disabled" || reason === "event-disabled") {
+          setStatus("E-mailnotificaties zijn uitgeschakeld.", "error");
+        } else if (reason === "no-recipients") {
+          setStatus("Geen ontvangers beschikbaar om te mailen.", "error");
+        } else {
+          setStatus("Versturen mislukt. Controleer de instellingen.", "error");
+        }
+        setDisabled(false);
+        state.sending = false;
+        return;
+      }
+      setStatus("Verstuurd", "success");
+      finish({ ok: true, payload });
+    } catch (error) {
+      console.error("Document mailen mislukt", error);
+      setStatus("Versturen mislukt.", "error");
+      setDisabled(false);
+      state.sending = false;
+    }
+  }
+
+  function handleTemplateChange() {
+    if (!state.options) return;
+    const selectedTemplate = getTemplateById(els.template?.value);
+    const templateFilled = fillTemplate(selectedTemplate, state.options.context || {});
+    if (els.subject) {
+      els.subject.value = templateFilled.subject || "";
+    }
+    if (els.body) {
+      els.body.value = templateFilled.body || "";
+    }
+  }
+
+  function handleListChange() {
+    updateListInfo();
+  }
+
+  form.addEventListener("submit", handleSubmit);
+  els.template?.addEventListener("change", handleTemplateChange);
+  els.list?.addEventListener("change", handleListChange);
+
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    if (state.sending) {
+      return;
+    }
+    finish({ ok: false, reason: "cancelled" });
+  });
+
+  dialog.addEventListener("close", () => {
+    resetStatus();
+    if (state.resolver) {
+      const resolver = state.resolver;
+      state.resolver = null;
+      resolver(state.result || { ok: false, reason: "cancelled" });
+    }
+  });
+
+  window.DocumentMail = {
+    open(options = {}) {
+      if (state.sending) {
+        return Promise.resolve({ ok: false, reason: "busy" });
+      }
+      state.options = options || {};
+      state.result = null;
+      populateForm(state.options);
+      return new Promise((resolve) => {
+        state.resolver = resolve;
+        dialog.showModal();
+      });
+    },
+  };
+})();

--- a/js/documents.js
+++ b/js/documents.js
@@ -1,0 +1,665 @@
+(function () {
+  const MM_TO_PT = 72 / 25.4;
+  const A4_WIDTH = 210 * MM_TO_PT;
+  const A4_HEIGHT = 297 * MM_TO_PT;
+  const DEFAULT_MARGIN = 18 * MM_TO_PT;
+
+  const FONT_KEYS = {
+    normal: "F1",
+    bold: "F2",
+  };
+
+  const DEFAULT_LINE_HEIGHT_FACTOR = 1.32;
+
+  const ESCAPE_MAP = {
+    "\\": "\\\\",
+    "(": "\\(",
+    ")": "\\)",
+  };
+
+  function escapePdfString(value) {
+    return value.replace(/[\\()]/g, (char) => ESCAPE_MAP[char] || char);
+  }
+
+  function stripDiacritics(value) {
+    if (typeof value.normalize === "function") {
+      return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+    }
+    return value;
+  }
+
+  function sanitizeText(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    const text = String(value)
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      .trim();
+    if (!text) {
+      return "";
+    }
+    const ascii = stripDiacritics(text).replace(/[^\x20-\x7E\n]+/g, "");
+    return ascii;
+  }
+
+  function splitLines(value) {
+    const clean = sanitizeText(value);
+    if (!clean) return [];
+    return clean.split(/\n+/);
+  }
+
+  function approximateCharWidth(fontSize) {
+    return fontSize * 0.53;
+  }
+
+  function wrapSingleLine(text, maxWidth, fontSize) {
+    const safeText = sanitizeText(text);
+    if (!safeText) return [""];
+    if (!maxWidth || maxWidth <= 0) {
+      return [safeText];
+    }
+    const approximateWidth = approximateCharWidth(fontSize);
+    const maxChars = Math.max(1, Math.floor(maxWidth / approximateWidth));
+    if (safeText.length <= maxChars) {
+      return [safeText];
+    }
+    const words = safeText.split(/\s+/);
+    const lines = [];
+    let current = "";
+    for (const word of words) {
+      if (!current) {
+        current = word;
+        continue;
+      }
+      if ((current + " " + word).length <= maxChars) {
+        current += " " + word;
+      } else {
+        lines.push(current);
+        current = word;
+      }
+    }
+    if (current) {
+      lines.push(current);
+    }
+    return lines;
+  }
+
+  function wrapText(text, maxWidth, fontSize) {
+    const sourceLines = splitLines(text);
+    if (!sourceLines.length) {
+      return [""];
+    }
+    const wrapped = [];
+    for (const line of sourceLines) {
+      const segments = wrapSingleLine(line, maxWidth, fontSize);
+      wrapped.push(...segments);
+    }
+    return wrapped;
+  }
+
+  function sum(array, endIndex) {
+    let total = 0;
+    for (let i = 0; i < array.length && (endIndex === undefined || i < endIndex); i += 1) {
+      total += array[i];
+    }
+    return total;
+  }
+
+  class PdfPage {
+    constructor(width, height, margin) {
+      this.width = width;
+      this.height = height;
+      this.margin = margin;
+      this.cursorY = height - margin;
+      this.content = [];
+    }
+
+    ensureSpace(amount) {
+      return this.cursorY - amount >= this.margin;
+    }
+
+    moveCursor(amount) {
+      this.cursorY -= amount;
+    }
+
+    write(operation) {
+      this.content.push(operation);
+    }
+
+    getContentStream() {
+      return this.content.join("\n");
+    }
+  }
+
+  class SimplePdf {
+    constructor(options = {}) {
+      this.width = options.width || A4_WIDTH;
+      this.height = options.height || A4_HEIGHT;
+      this.margin = options.margin || DEFAULT_MARGIN;
+      this.pages = [];
+    }
+
+    getCurrentPage(requiredSpace = 0) {
+      let page = this.pages[this.pages.length - 1];
+      if (!page || (requiredSpace && !page.ensureSpace(requiredSpace))) {
+        page = new PdfPage(this.width, this.height, this.margin);
+        this.pages.push(page);
+      }
+      return page;
+    }
+
+    addSpacing(amount) {
+      const page = this.getCurrentPage();
+      page.moveCursor(amount);
+    }
+
+    addText(text, options = {}) {
+      const fontSize = options.fontSize || 12;
+      const fontKey = options.font === "bold" ? FONT_KEYS.bold : FONT_KEYS.normal;
+      const lineHeight = fontSize * (options.lineHeightFactor || DEFAULT_LINE_HEIGHT_FACTOR);
+      const indent = options.indent || 0;
+      const maxWidth = this.width - this.margin * 2 - indent;
+      const lines = wrapText(text, maxWidth, fontSize);
+      const blockHeight = lineHeight * lines.length;
+      const page = this.getCurrentPage(blockHeight + lineHeight * 0.25);
+      const baseY = page.cursorY;
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i];
+        const textY = baseY - fontSize - i * lineHeight + fontSize * 0.3;
+        const escaped = escapePdfString(line);
+        page.write(`BT /${fontKey} ${fontSize} Tf 1 0 0 1 ${Math.round((this.margin + indent) * 100) / 100} ${Math.round(textY * 100) / 100} Tm (${escaped}) Tj ET`);
+      }
+      page.cursorY = baseY - blockHeight - lineHeight * 0.3;
+    }
+
+    addTitle(text) {
+      this.addText(text, { fontSize: 20, font: "bold", lineHeightFactor: 1.18 });
+      this.addSpacing(8);
+    }
+
+    addSubtitle(text) {
+      this.addText(text, { fontSize: 14, font: "bold", lineHeightFactor: 1.2 });
+      this.addSpacing(4);
+    }
+
+    addSectionTitle(text) {
+      this.addSpacing(6);
+      this.addText(text, { fontSize: 13, font: "bold", lineHeightFactor: 1.2 });
+      this.addSpacing(4);
+    }
+
+    addParagraph(text, options = {}) {
+      this.addText(text, { fontSize: options.fontSize || 11, lineHeightFactor: 1.3, indent: options.indent || 0 });
+      this.addSpacing(options.spacingAfter || 6);
+    }
+
+    addKeyValueRows(rows, options = {}) {
+      if (!Array.isArray(rows) || !rows.length) {
+        return;
+      }
+      const fontSize = options.fontSize || 11;
+      const labelWidth = options.labelWidth || 120;
+      const spacing = options.spacingAfter || 6;
+      const lineHeight = fontSize * DEFAULT_LINE_HEIGHT_FACTOR;
+      const contentWidth = this.width - this.margin * 2 - labelWidth - 12;
+      for (const row of rows) {
+        const label = row.term || row.label || "";
+        const value = row.value || "";
+        const valueLines = wrapText(value, contentWidth, fontSize);
+        const blockHeight = Math.max(lineHeight, valueLines.length * lineHeight);
+        const page = this.getCurrentPage(blockHeight + fontSize);
+        const baseY = page.cursorY;
+        const labelY = baseY - fontSize + fontSize * 0.25;
+        const labelText = escapePdfString(sanitizeText(label));
+        page.write(`BT /${FONT_KEYS.bold} ${fontSize} Tf 1 0 0 1 ${Math.round(this.margin * 100) / 100} ${Math.round(labelY * 100) / 100} Tm (${labelText}) Tj ET`);
+        for (let i = 0; i < valueLines.length; i += 1) {
+          const line = valueLines[i];
+          const lineY = baseY - fontSize - i * lineHeight + fontSize * 0.3;
+          const escaped = escapePdfString(line);
+          page.write(`BT /${FONT_KEYS.normal} ${fontSize} Tf 1 0 0 1 ${Math.round((this.margin + labelWidth + 12) * 100) / 100} ${Math.round(lineY * 100) / 100} Tm (${escaped}) Tj ET`);
+        }
+        page.cursorY = baseY - blockHeight - fontSize * 0.3;
+      }
+      this.addSpacing(spacing);
+    }
+
+    addTable({ headers, rows, columnWidths, fontSize = 10, spacingAfter = 10 }) {
+      if (!Array.isArray(headers) || !headers.length) {
+        return;
+      }
+      const columns = headers.length;
+      const availableWidth = this.width - this.margin * 2;
+      let widths = columnWidths;
+      if (!Array.isArray(widths) || widths.length !== columns) {
+        const evenWidth = availableWidth / columns;
+        widths = new Array(columns).fill(evenWidth);
+      }
+      const normalizedWidths = widths.map((width) => Math.max(40, width));
+      const totalWidth = normalizedWidths.reduce((acc, value) => acc + value, 0);
+      const scale = availableWidth / totalWidth;
+      const scaledWidths = normalizedWidths.map((width) => width * scale);
+      const paddingX = 6;
+      const paddingY = 4;
+      const lineHeight = fontSize * DEFAULT_LINE_HEIGHT_FACTOR;
+
+      const wrapRow = (row, isHeader = false) => {
+        const cells = [];
+        for (let i = 0; i < columns; i += 1) {
+          const raw = row[i] ?? "";
+          const lines = wrapText(raw, scaledWidths[i] - paddingX * 2, fontSize);
+          cells.push({
+            text: lines,
+            font: isHeader ? FONT_KEYS.bold : FONT_KEYS.normal,
+          });
+        }
+        return cells;
+      };
+
+      const headerCells = wrapRow(headers, true);
+      const headerHeight = headerCells.reduce((max, cell) => Math.max(max, cell.text.length), 1) * lineHeight + paddingY * 2;
+      let page = this.getCurrentPage(headerHeight + fontSize);
+      if (!page.ensureSpace(headerHeight + fontSize)) {
+        page = this.getCurrentPage(headerHeight + fontSize);
+      }
+      let currentY = page.cursorY;
+      for (let i = 0; i < columns; i += 1) {
+        const cell = headerCells[i];
+        const cellX = this.margin + sum(scaledWidths, i);
+        for (let lineIndex = 0; lineIndex < cell.text.length; lineIndex += 1) {
+          const line = cell.text[lineIndex];
+          const lineY = currentY - paddingY - fontSize - lineIndex * lineHeight + fontSize * 0.3;
+          const escaped = escapePdfString(line);
+          page.write(`BT /${cell.font} ${fontSize} Tf 1 0 0 1 ${Math.round((cellX + paddingX) * 100) / 100} ${Math.round(lineY * 100) / 100} Tm (${escaped}) Tj ET`);
+        }
+      }
+      currentY -= headerHeight;
+      page.cursorY = currentY;
+
+      if (!Array.isArray(rows)) {
+        rows = [];
+      }
+      for (const row of rows) {
+        const wrappedRow = wrapRow(row, false);
+        const rowHeight = wrappedRow.reduce((max, cell) => Math.max(max, cell.text.length), 1) * lineHeight + paddingY * 2;
+        page = this.getCurrentPage(rowHeight + fontSize);
+        currentY = page.cursorY;
+        for (let i = 0; i < columns; i += 1) {
+          const cell = wrappedRow[i];
+          const cellX = this.margin + sum(scaledWidths, i);
+          for (let lineIndex = 0; lineIndex < cell.text.length; lineIndex += 1) {
+            const line = cell.text[lineIndex];
+            const lineY = currentY - paddingY - fontSize - lineIndex * lineHeight + fontSize * 0.3;
+            const escaped = escapePdfString(line);
+            page.write(`BT /${cell.font} ${fontSize} Tf 1 0 0 1 ${Math.round((cellX + paddingX) * 100) / 100} ${Math.round(lineY * 100) / 100} Tm (${escaped}) Tj ET`);
+          }
+        }
+        page.cursorY = currentY - rowHeight;
+      }
+      this.addSpacing(spacingAfter);
+    }
+
+    async toBlob() {
+      if (!this.pages.length) {
+        this.getCurrentPage();
+      }
+      const objects = [];
+      const offsets = [];
+
+      const pushObject = (body = "") => {
+        const id = objects.length + 1;
+        objects.push({ id, body });
+        return id;
+      };
+
+      const catalogId = pushObject();
+      const pagesTreeId = pushObject();
+      const contentIds = [];
+      const pageIds = [];
+      for (let i = 0; i < this.pages.length; i += 1) {
+        contentIds.push(pushObject());
+        pageIds.push(pushObject());
+      }
+      const fontNormalId = pushObject();
+      const fontBoldId = pushObject();
+
+      for (let i = 0; i < this.pages.length; i += 1) {
+        const page = this.pages[i];
+        const contentStream = page.getContentStream();
+        const contentBody = `<< /Length ${contentStream.length} >>\nstream\n${contentStream}\nendstream`;
+        objects[contentIds[i] - 1].body = contentBody;
+        const pageBody = [
+          "<<",
+          " /Type /Page",
+          ` /Parent ${pagesTreeId} 0 R`,
+          ` /MediaBox [0 0 ${this.width.toFixed(2)} ${this.height.toFixed(2)}]`,
+          " /Resources << /Font <<",
+          `  /${FONT_KEYS.normal} ${fontNormalId} 0 R`,
+          `  /${FONT_KEYS.bold} ${fontBoldId} 0 R`,
+          " >> >>",
+          ` /Contents ${contentIds[i]} 0 R`,
+          " >>",
+        ].join("\n");
+        objects[pageIds[i] - 1].body = pageBody;
+      }
+
+      const pagesBody = `<< /Type /Pages /Count ${this.pages.length} /Kids [${pageIds
+        .map((id) => `${id} 0 R`)
+        .join(" ")}] >>`;
+      objects[pagesTreeId - 1].body = pagesBody;
+      objects[catalogId - 1].body = `<< /Type /Catalog /Pages ${pagesTreeId} 0 R >>`;
+      objects[fontNormalId - 1].body = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+      objects[fontBoldId - 1].body = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>";
+
+      let pdf = "%PDF-1.4\n";
+      for (const object of objects) {
+        offsets.push(pdf.length);
+        pdf += `${object.id} 0 obj\n${object.body}\nendobj\n`;
+      }
+      const xrefStart = pdf.length;
+      pdf += "xref\n";
+      pdf += `0 ${objects.length + 1}\n`;
+      pdf += "0000000000 65535 f \n";
+      for (const offset of offsets) {
+        const padded = offset.toString().padStart(10, "0");
+        pdf += `${padded} 00000 n \n`;
+      }
+      pdf += "trailer\n";
+      pdf += `<< /Size ${objects.length + 1} /Root ${catalogId} 0 R >>\n`;
+      pdf += "startxref\n";
+      pdf += `${xrefStart}\n`;
+      pdf += "%%EOF";
+
+      return new Blob([pdf], { type: "application/pdf" });
+    }
+  }
+
+  function safeNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function joinNonEmpty(values, separator = " ") {
+    if (!Array.isArray(values)) {
+      return "";
+    }
+    const filtered = values
+      .map((value) => sanitizeText(value))
+      .filter((value) => value && value.trim().length);
+    return filtered.join(separator);
+  }
+
+  function formatDate(value) {
+    if (!value && value !== 0) return "";
+    const parsed = new Date(value);
+    if (!Number.isFinite(parsed.getTime())) {
+      const text = sanitizeText(value);
+      return text || "";
+    }
+    const day = String(parsed.getDate()).padStart(2, "0");
+    const month = String(parsed.getMonth() + 1).padStart(2, "0");
+    const year = parsed.getFullYear();
+    return `${day}-${month}-${year}`;
+  }
+
+  function formatDateTime(value) {
+    if (!value && value !== 0) return "";
+    const parsed = new Date(value);
+    if (!Number.isFinite(parsed.getTime())) {
+      const text = sanitizeText(value);
+      return text || "";
+    }
+    const datePart = formatDate(parsed);
+    const hours = String(parsed.getHours()).padStart(2, "0");
+    const minutes = String(parsed.getMinutes()).padStart(2, "0");
+    return `${datePart} ${hours}:${minutes}`;
+  }
+
+  function formatStopDetails(stop) {
+    if (!stop || typeof stop !== "object") {
+      return "";
+    }
+    const location = sanitizeText(stop.location);
+    const date = stop.date ? formatDate(stop.date) : "";
+    const slot = sanitizeText(stop.slot) || joinNonEmpty([stop.time_from, stop.time_to], " - ");
+    return joinNonEmpty([
+      location,
+      joinNonEmpty([date, slot], " • "),
+    ], "\n");
+  }
+
+  function buildRouteRows(group) {
+    if (!group || !Array.isArray(group.stops)) {
+      return [];
+    }
+    return group.stops.map((stop, index) => {
+      const order = stop.order || {};
+      const details = stop.details || {};
+      const reference = sanitizeText(
+        order.request_reference ||
+          order.reference ||
+          order.customer_order_number ||
+          order.customer_name ||
+          (order.id ? `Order #${order.id}` : "Opdracht")
+      );
+      const customer = sanitizeText(order.customer_name);
+      const addressLines = [];
+      const pickup = formatStopDetails(details.pickup);
+      if (pickup) {
+        addressLines.push(`Laad: ${pickup}`);
+      }
+      const delivery = formatStopDetails(details.delivery);
+      if (delivery) {
+        addressLines.push(`Los: ${delivery}`);
+      }
+      const planningDate = order.planned_date ? formatDate(order.planned_date) : formatDate(details.delivery?.date);
+      const planningSlot = sanitizeText(order.planned_slot) || sanitizeText(details.delivery?.slot);
+      const dueDate = order.due_date ? formatDate(order.due_date) : "";
+      const planningLines = [];
+      if (planningDate || planningSlot) {
+        planningLines.push(joinNonEmpty([planningDate, planningSlot], " • "));
+      }
+      if (dueDate && dueDate !== planningDate) {
+        planningLines.push(`Gewenste levering: ${dueDate}`);
+      }
+      const contact = joinNonEmpty([
+        details.contactName,
+        details.contactPhone,
+        details.contactEmail,
+      ], "\n");
+      return [
+        String(index + 1),
+        joinNonEmpty([reference, customer], "\n"),
+        addressLines.join("\n"),
+        planningLines.join("\n") || "-",
+        contact || "-",
+      ];
+    });
+  }
+
+  function countStops(snapshot) {
+    if (!snapshot || !Array.isArray(snapshot.groups)) {
+      return 0;
+    }
+    return snapshot.groups.reduce((sum, group) => sum + (Array.isArray(group.stops) ? group.stops.length : 0), 0);
+  }
+
+  async function generateRouteListPdf(snapshot, options = {}) {
+    const pdf = new SimplePdf();
+    const dateLabel = snapshot?.date ? formatDate(snapshot.date) : "Onbekende datum";
+    const title = `Rittenlijst ${dateLabel}`;
+    pdf.addTitle(title);
+    const totalRoutes = Array.isArray(snapshot?.groups) ? snapshot.groups.length : 0;
+    const totalStops = countStops(snapshot);
+    const backlogCount = Array.isArray(snapshot?.backlog) ? snapshot.backlog.length : 0;
+    const generatedLabel = snapshot?.generatedAt ? formatDateTime(snapshot.generatedAt) : formatDateTime(new Date().toISOString());
+    pdf.addParagraph(
+      `Gegenereerd: ${generatedLabel || "-"}. Routes: ${totalRoutes}. Stops: ${totalStops}. Backlog: ${backlogCount}.`,
+      { fontSize: 11, spacingAfter: 12 }
+    );
+
+    if (Array.isArray(snapshot?.groups) && snapshot.groups.length) {
+      snapshot.groups.forEach((group, groupIndex) => {
+        const label = sanitizeText(group.label || group.carrier) || `Route ${groupIndex + 1}`;
+        pdf.addSectionTitle(`${groupIndex + 1}. ${label}`);
+        const metaParts = [];
+        if (group.carrier) {
+          metaParts.push(`Carrier: ${sanitizeText(group.carrier)}`);
+        }
+        if (safeNumber(group.distance) !== null) {
+          metaParts.push(`Geschatte afstand: ${safeNumber(group.distance).toFixed(1)} km`);
+        }
+        metaParts.push(`Stops: ${Array.isArray(group.stops) ? group.stops.length : 0}`);
+        pdf.addParagraph(metaParts.join(" • "), { fontSize: 10, spacingAfter: 4 });
+        const rows = buildRouteRows(group);
+        pdf.addTable({
+          headers: ["#", "Opdracht", "Adressen", "Planning", "Contact"],
+          rows: rows.length ? rows : [["-", "Geen opdrachten", "", "", ""]],
+          columnWidths: [28, 160, 160, 110, 110],
+        });
+      });
+    } else {
+      pdf.addParagraph("Geen routes beschikbaar voor de geselecteerde datum.", { fontSize: 11 });
+    }
+
+    if (Array.isArray(snapshot?.backlog) && snapshot.backlog.length) {
+      pdf.addSectionTitle("Backlog / nog te plannen");
+      const backlogRows = buildRouteRows({ stops: snapshot.backlog });
+      pdf.addTable({
+        headers: ["#", "Opdracht", "Adressen", "Planning", "Contact"],
+        rows: backlogRows,
+        columnWidths: [28, 160, 160, 110, 110],
+      });
+    }
+
+    pdf.addParagraph("Automatisch gegenereerd vanuit de routekaart.", { fontSize: 9, spacingAfter: 0 });
+
+    return pdf.toBlob();
+  }
+
+  function buildGoodsTableRows(lines) {
+    if (!Array.isArray(lines) || !lines.length) {
+      return [["-", "Geen goederen geregistreerd", "", ""]];
+    }
+    return lines.map((line, index) => {
+      const quantity = line.quantity !== null && line.quantity !== undefined ? String(line.quantity) : "-";
+      return [
+        String(index + 1),
+        sanitizeText(line.product) || "-",
+        quantity,
+        sanitizeText(line.serialNumber) || "-",
+      ];
+    });
+  }
+
+  async function generateCmrPdf(order, details, lines = [], options = {}) {
+    const pdf = new SimplePdf();
+    const safeOrder = order || {};
+    const safeDetails = details || {};
+    const reference = sanitizeText(
+      safeDetails.reference ||
+        safeOrder.request_reference ||
+        safeOrder.reference ||
+        safeOrder.customer_order_number ||
+        (safeOrder.id ? `Order #${safeOrder.id}` : "Transportopdracht")
+    );
+
+    pdf.addTitle("CMR / Vrachtbrief");
+    pdf.addSubtitle(reference || "Onbekende referentie");
+    const summaryParts = [];
+    if (safeOrder.customer_name) {
+      summaryParts.push(`Klant: ${sanitizeText(safeOrder.customer_name)}`);
+    }
+    if (safeOrder.order_reference) {
+      summaryParts.push(`Orderref: ${sanitizeText(safeOrder.order_reference)}`);
+    }
+    if (safeOrder.customer_order_number || safeDetails.customerOrderNumber) {
+      summaryParts.push(`PO: ${sanitizeText(safeOrder.customer_order_number || safeDetails.customerOrderNumber)}`);
+    }
+    if (safeOrder.assigned_carrier) {
+      summaryParts.push(`Vervoerder: ${sanitizeText(safeOrder.assigned_carrier)}`);
+    }
+    if (summaryParts.length) {
+      pdf.addParagraph(summaryParts.join(" • "), { fontSize: 11, spacingAfter: 8 });
+    }
+
+    const plannedDate = safeOrder.planned_date || safeDetails.pickup?.date;
+    const deliveryDate = safeOrder.due_date || safeDetails.delivery?.date;
+    pdf.addKeyValueRows(
+      [
+        { term: "Geplande datum", value: formatDate(plannedDate) || "-" },
+        { term: "Gewenste levering", value: formatDate(deliveryDate) || "-" },
+        { term: "Transporttype", value: sanitizeText(safeDetails.transportType || safeOrder.transport_type) || "-" },
+      ],
+      { spacingAfter: 10 }
+    );
+
+    pdf.addSectionTitle("Afzender / laadadres");
+    pdf.addKeyValueRows(
+      [
+        { term: "Adres", value: formatStopDetails(safeDetails.pickup) || "-" },
+        {
+          term: "Contact",
+          value:
+            joinNonEmpty(
+              [safeDetails.pickup?.contact, safeDetails.pickup?.phone],
+              " \u2022 "
+            ) || "-",
+        },
+      ],
+      { spacingAfter: 8 }
+    );
+
+    pdf.addSectionTitle("Geadresseerde / losadres");
+    pdf.addKeyValueRows(
+      [
+        { term: "Adres", value: formatStopDetails(safeDetails.delivery) || "-" },
+        {
+          term: "Contact",
+          value:
+            joinNonEmpty(
+              [safeDetails.delivery?.contact, safeDetails.delivery?.phone],
+              " \u2022 "
+            ) || "-",
+        },
+      ],
+      { spacingAfter: 8 }
+    );
+
+    pdf.addSectionTitle("Goederen");
+    pdf.addTable({
+      headers: ["#", "Omschrijving", "Aantal", "Serienummer"],
+      rows: buildGoodsTableRows(lines),
+      columnWidths: [30, 260, 80, 120],
+    });
+
+    pdf.addSectionTitle("Instructies en opmerkingen");
+    const instructions = safeDetails.instructions || safeOrder.notes;
+    pdf.addParagraph(instructions ? sanitizeText(instructions) : "Geen aanvullende instructies bekend.", {
+      fontSize: 10,
+      spacingAfter: 12,
+    });
+
+    pdf.addSectionTitle("Handtekeningen");
+    pdf.addParagraph(
+      [
+        "Handtekening afzender: ________________________________",
+        "Handtekening vervoerder: ______________________________",
+        "Handtekening geadresseerde: ___________________________",
+      ].join("\n"),
+      { fontSize: 10, spacingAfter: 12 }
+    );
+
+    pdf.addParagraph("Automatisch gegenereerde CMR op basis van ordergegevens.", {
+      fontSize: 9,
+      spacingAfter: 0,
+    });
+
+    return pdf.toBlob();
+  }
+
+  window.TransportDocuments = {
+    generateRouteListPdf,
+    generateCmrPdf,
+  };
+})();

--- a/partials/orders.html
+++ b/partials/orders.html
@@ -165,6 +165,8 @@
       <menu class="menu">
         <button value="cancel" class="btn ghost">Annuleren</button>
         <button id="btnPrintOrder" type="button" class="btn ghost">Print bon</button>
+        <button id="btnDownloadCmr" type="button" class="btn ghost">Download CMR</button>
+        <button id="btnEmailCmr" type="button" class="btn ghost">Mail CMR</button>
         <button id="btnDeleteOrder" type="button" class="btn danger" data-role-visible="admin,planner,werknemer">Verwijderen</button>
         <button id="btnSaveEdit" value="default" class="btn primary">Opslaan</button>
       </menu>

--- a/partials/routekaart.html
+++ b/partials/routekaart.html
@@ -16,7 +16,29 @@
       </label>
       <button class="btn" id="btnRebuildRoutes">Herbereken</button>
       <button class="btn ghost" id="btnResetView">Reset view</button>
-      <button class="btn ghost" id="btnPrintRoutes">Print / export</button>
+      <div class="export-menu" data-export-menu>
+        <button
+          class="btn ghost export-menu__toggle"
+          id="btnRouteDocuments"
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          aria-controls="routeDocumentsMenu"
+        >
+          Documenten
+        </button>
+        <div
+          class="export-menu__panel"
+          id="routeDocumentsMenu"
+          data-export-menu-panel
+          role="menu"
+          hidden
+        >
+          <button type="button" class="export-menu__item" data-export-format="print" role="menuitem">Printweergave</button>
+          <button type="button" class="export-menu__item" data-export-format="pdf" role="menuitem">Download rittenlijst (PDF)</button>
+          <button type="button" class="export-menu__item" data-export-format="email" role="menuitem">Mail rittenlijst</button>
+        </div>
+      </div>
     </div>
     <div id="routesStatus" class="status" role="status"></div>
     <div class="map-shell">

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -50,6 +50,12 @@ function loadEnvValues() {
     values.EMAIL_NOTIFICATIONS_ENABLED_EVENTS =
       process.env.EMAIL_NOTIFICATIONS_ENABLED_EVENTS;
   }
+  if (process.env.DOCUMENT_EMAIL_TEMPLATES) {
+    values.DOCUMENT_EMAIL_TEMPLATES = process.env.DOCUMENT_EMAIL_TEMPLATES;
+  }
+  if (process.env.DOCUMENT_EMAIL_LISTS) {
+    values.DOCUMENT_EMAIL_LISTS = process.env.DOCUMENT_EMAIL_LISTS;
+  }
 
   if ((!values.SUPABASE_URL || !values.SUPABASE_ANON_KEY) && fs.existsSync(ENV_FILE_PATH)) {
     const fileEnv = parseEnv(fs.readFileSync(ENV_FILE_PATH, "utf8"));
@@ -62,6 +68,10 @@ function loadEnvValues() {
       fileEnv.EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS;
     values.EMAIL_NOTIFICATIONS_ENABLED_EVENTS =
       values.EMAIL_NOTIFICATIONS_ENABLED_EVENTS || fileEnv.EMAIL_NOTIFICATIONS_ENABLED_EVENTS;
+    values.DOCUMENT_EMAIL_TEMPLATES =
+      values.DOCUMENT_EMAIL_TEMPLATES || fileEnv.DOCUMENT_EMAIL_TEMPLATES;
+    values.DOCUMENT_EMAIL_LISTS =
+      values.DOCUMENT_EMAIL_LISTS || fileEnv.DOCUMENT_EMAIL_LISTS;
   }
 
   return values;
@@ -96,6 +106,8 @@ function build() {
       envValues.EMAIL_NOTIFICATIONS_DEFAULT_RECIPIENTS || "",
     EMAIL_NOTIFICATIONS_ENABLED_EVENTS:
       envValues.EMAIL_NOTIFICATIONS_ENABLED_EVENTS || "",
+    DOCUMENT_EMAIL_TEMPLATES: envValues.DOCUMENT_EMAIL_TEMPLATES || "",
+    DOCUMENT_EMAIL_LISTS: envValues.DOCUMENT_EMAIL_LISTS || "",
   };
 
   const serialized = Object.entries(configEntries)

--- a/styles.css
+++ b/styles.css
@@ -1595,6 +1595,59 @@ dialog::backdrop {
   background: rgba(43, 43, 43, 0.4);
 }
 
+.document-mail-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.document-mail {
+  max-width: 520px;
+  width: min(520px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.document-mail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.document-mail__header h3 {
+  margin: 0;
+}
+
+.document-mail__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.95rem;
+}
+
+.document-mail__field input,
+.document-mail__field textarea,
+.document-mail__field select {
+  width: 100%;
+}
+
+.document-mail__status {
+  min-height: 1.2rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.document-mail__status.is-error {
+  color: #b3261e;
+}
+
+.document-mail__status.is-success {
+  color: #1b5e20;
+}
+
+.document-mail__actions {
+  justify-content: flex-end;
+}
+
 .menu {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- add a client-side PDF generator for route overviews and CMRs and expose download/email actions in the UI
- introduce a reusable document mail dialog with configurable templates, distribution lists, and attachment support
- update configuration and export workflows so route exports offer print, PDF download, and email delivery options

## Testing
- npm run build:env *(fails: Missing required environment variables SUPABASE_URL, SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c54d9aa8832b853ad8b831dd8ae9