### PR TITLE
Allow selecting Motrac branches for order pickup and delivery

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -157,6 +157,11 @@
               <label>Pickup contact telefoon
                 <input id="oPickupPhone" placeholder="Telefoon laadcontact" />
               </label>
+              <label>Vestiging (optioneel)
+                <select id="oPickupBranch" data-placeholder="Kies een vestiging">
+                  <option value="">Kies een vestiging</option>
+                </select>
+              </label>
               <label>Locatie
                 <input id="oPickupLocation" placeholder="Straat, nummer, plaats" />
               </label>
@@ -223,6 +228,11 @@
               </label>
               <label>Los contact telefoon
                 <input id="oDeliveryPhone" placeholder="Telefoon loscontact" />
+              </label>
+              <label>Vestiging (optioneel)
+                <select id="oDeliveryBranch" data-placeholder="Kies een vestiging">
+                  <option value="">Kies een vestiging</option>
+                </select>
               </label>
               <label>Locatie
                 <input id="oDeliveryLocation" placeholder="Straat, nummer, plaats" />


### PR DESCRIPTION
## Summary
- add optional branch selectors to the pickup and delivery sections of the aanvraag wizard
- centralize the list of Motrac branches and sync the selectors with the existing location fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e35464b9a4832b9c36cd5ecfd9b2e3