### PR TITLE
Improve orders table search and toolbar

### DIFF
--- a/partials/orders.html
+++ b/partials/orders.html
@@ -29,9 +29,6 @@
         <label>Ordernummer klant / PO
           <input id="filterCustomerOrder" type="search" placeholder="Bijv. PO-12345" />
         </label>
-        <label>Zoekopdracht
-          <input id="filterQuery" type="search" placeholder="Referentie, notities, adressen" />
-        </label>
         <label>Leverdatum
           <input id="filterDate" type="date" />
         </label>
@@ -46,6 +43,17 @@
       <div class="bar">
         <h2>Orders</h2>
         <div class="bar-actions">
+          <div class="orders-search">
+            <label class="visually-hidden" for="filterQuery">Zoeken in orders</label>
+            <input
+              id="filterQuery"
+              class="orders-search__input"
+              type="search"
+              placeholder="Zoeken op order, klant of status"
+              aria-label="Zoeken in orders"
+              autocomplete="off"
+            />
+          </div>
           <div class="muted small">Klik op een regel om details te bewerken.</div>
           <div class="export-menu" data-export-menu>
             <button

--- a/styles.css
+++ b/styles.css
@@ -109,6 +109,18 @@ h4 {
   color: var(--color-muted);
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 .site-header {
   padding: 24px 16px;
   background: var(--color-surface);
@@ -1451,6 +1463,47 @@ td {
 
 .bar-actions .muted {
   margin-right: auto;
+}
+
+.orders-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 240px;
+  min-width: 200px;
+}
+
+.orders-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.orders-search__input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(176, 0, 32, 0.15);
+  outline: none;
+}
+
+.orders-search__input::placeholder {
+  color: var(--color-muted);
+  opacity: 0.8;
+}
+
+@media (max-width: 720px) {
+  .orders-search {
+    flex-basis: 100%;
+  }
+
+  .bar-actions .muted {
+    order: 3;
+    margin-right: 0;
+  }
 }
 
 .export-menu {


### PR DESCRIPTION
## Summary
- move the orders search field into the table toolbar for quicker filtering while keeping sorting/export controls accessible
- add supporting styles, including a reusable visually hidden utility, so the toolbar search adapts across screen sizes

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e367272e5c832b876865400b6dea9d