### PR TITLE
Add icon controls and confirmations for fleet management

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1179,6 +1179,33 @@ textarea {
   gap: 10px;
 }
 
+.btn.icon-only {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  padding: 6px;
+  min-height: 36px;
+  min-width: 36px;
+  width: 36px;
+}
+
+.btn.icon-only .btn__icon {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
+.btn.icon-only .btn__icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.btn.icon-only:hover .btn__icon,
+.btn.icon-only:focus-visible .btn__icon {
+  background: var(--color-icon-muted-bg);
+}
+
 .btn__icon {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace carrier and truck list actions with accessible icon buttons
- show success toasts after saving trucks and confirm before removing a truck and its planning
- reuse shared helpers for consistent carrier/truck edit and delete feedback

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e36ce2a47c832b919266bf2334dec2