### PR TITLE
Remove helper text from aanvraag page

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -2,7 +2,6 @@
   <section class="card order-card">
     <div class="bar">
       <h2>Transportgegevens</h2>
-      <div class="muted small">Leg nieuwe transportaanvragen vast op basis van de Bizagi-velden.</div>
     </div>
     <form id="orderForm" class="form-sections wizard-form" novalidate>
       <nav class="wizard-stepper" aria-label="Stappen voor nieuwe aanvraag">


### PR DESCRIPTION
## Summary
- remove the Bizagi helper message from the aanvraag form header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37d663bc0832bac1c49d1ee0b1306