### PR TITLE
Make signup panel collapsible on login page

### DIFF
--- a/partials/login.html
+++ b/partials/login.html
@@ -14,26 +14,30 @@
     <div id="loginStatus" class="status" role="status"></div>
   </section>
 
-  <section class="card narrow">
-    <h2>Account aanvragen</h2>
-    <p class="muted small">
-      Vraag zelf een account aan met je e-mailadres. Een beheerder wijst daarna je definitieve rol toe.
-    </p>
-    <form id="signupForm" class="stack" novalidate>
-      <label>E-mailadres
-        <input type="email" id="signupEmail" required autocomplete="email" placeholder="naam@voorbeeld.nl" />
-      </label>
-      <label>Wachtwoord
-        <input type="password" id="signupPassword" required minlength="6" autocomplete="new-password" />
-      </label>
-      <label>Bevestig wachtwoord
-        <input type="password" id="signupPasswordConfirm" required minlength="6" autocomplete="new-password" />
-      </label>
-      <button class="btn secondary" type="submit" id="btnSignup">Account aanvragen</button>
-    </form>
-    <div id="signupStatus" class="status" role="status"></div>
-    <p class="muted small">
-      Ben je beheerder en wil je iemand anders toevoegen? <a href="create-user.html" data-route="create-user">Gebruik dan het beheerdersformulier</a>.
-    </p>
-  </section>
+  <details class="card narrow collapsible" id="signupPanel">
+    <summary>
+      <h2>Account aanvragen</h2>
+    </summary>
+    <div class="collapsible-content">
+      <p class="muted small">
+        Vraag zelf een account aan met je e-mailadres. Een beheerder wijst daarna je definitieve rol toe.
+      </p>
+      <form id="signupForm" class="stack" novalidate>
+        <label>E-mailadres
+          <input type="email" id="signupEmail" required autocomplete="email" placeholder="naam@voorbeeld.nl" />
+        </label>
+        <label>Wachtwoord
+          <input type="password" id="signupPassword" required minlength="6" autocomplete="new-password" />
+        </label>
+        <label>Bevestig wachtwoord
+          <input type="password" id="signupPasswordConfirm" required minlength="6" autocomplete="new-password" />
+        </label>
+        <button class="btn secondary" type="submit" id="btnSignup">Account aanvragen</button>
+      </form>
+      <div id="signupStatus" class="status" role="status"></div>
+      <p class="muted small">
+        Ben je beheerder en wil je iemand anders toevoegen? <a href="create-user.html" data-route="create-user">Gebruik dan het beheerdersformulier</a>.
+      </p>
+    </div>
+  </details>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -391,6 +391,50 @@ h4 {
   transition: background-color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, color 0.25s ease;
 }
 
+.collapsible {
+  padding: 0;
+}
+
+.collapsible summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.collapsible summary::-webkit-details-marker {
+  display: none;
+}
+
+.collapsible summary::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 0.2s ease;
+}
+
+.collapsible[open] summary::before {
+  transform: rotate(45deg);
+}
+
+.collapsible summary h2 {
+  margin: 0;
+}
+
+.collapsible .collapsible-content {
+  padding: 0 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border-top: 1px solid var(--color-border);
+}
+
 .order-card {
   background: var(--color-highlight-bg);
   border-color: var(--color-highlight-border);


### PR DESCRIPTION
## Summary
- turn the account request card on the login page into a collapsible details element that is closed by default
- add styling for the collapsible summary, indicator arrow, and content spacing to keep the card layout consistent

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e37e46d108832bb08bcf9ac38a5829