### PR TITLE
Restore aanvraag stamgegevens header layout

### DIFF
--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -47,6 +47,21 @@
         </ol>
       </nav>
 
+      <section class="order-mini-summary" aria-label="Stamgegevens">
+        <div class="order-mini-summary__item">
+          <span class="order-mini-summary__label">REF</span>
+          <span class="order-mini-summary__value" data-summary-field="reference">-</span>
+        </div>
+        <div class="order-mini-summary__item">
+          <span class="order-mini-summary__label">Klantnaam</span>
+          <span class="order-mini-summary__value" data-summary-field="customer">-</span>
+        </div>
+        <div class="order-mini-summary__item">
+          <span class="order-mini-summary__label">Gewenste leverdatum</span>
+          <span class="order-mini-summary__value" data-summary-field="due">-</span>
+        </div>
+      </section>
+
       <div id="wizardStatus" class="status" aria-live="polite"></div>
 
       <section class="form-section wizard-panel" data-order-step="1">

--- a/styles.css
+++ b/styles.css
@@ -813,6 +813,47 @@ h4 {
   margin-bottom: 24px;
 }
 
+.order-mini-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px 24px;
+  margin-bottom: 20px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-subtle-surface);
+}
+
+.order-mini-summary__item {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.order-mini-summary__label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.order-mini-summary__value {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 14px;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .order-mini-summary {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 8px 16px;
+    margin-bottom: 16px;
+  }
+}
+
 .wizard-progress {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure the stamgegevens mini summary reuses the existing order summary update logic so values stay in sync
- restyle the mini summary banner with a lightweight, responsive grid that matches the wizard layout without breaking the UI

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e3805dd0a8832bb903d97ff17178cc