### PR TITLE
Add first work toggle to transport request form

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -462,6 +462,14 @@
       if (dueDate && dueDate !== planningDate) {
         planningLines.push(`Gewenste levering: ${dueDate}`);
       }
+      const firstWorkLabel = typeof details.firstWork === "boolean"
+        ? details.firstWork
+          ? "Ja"
+          : "Nee"
+        : "";
+      if (firstWorkLabel) {
+        planningLines.push(`Eerste werk: ${firstWorkLabel}`);
+      }
       const contact = joinNonEmpty([
         details.contactName,
         details.contactPhone,

--- a/js/routes.js
+++ b/js/routes.js
@@ -181,6 +181,7 @@
         contactName: null,
         contactPhone: null,
         contactEmail: null,
+        firstWork: null,
       };
     }
     return {
@@ -197,6 +198,7 @@
       contactName: details.contactName || null,
       contactPhone: details.contactPhone || null,
       contactEmail: details.contactEmail || null,
+      firstWork: typeof details.firstWork === "boolean" ? details.firstWork : null,
     };
   }
 
@@ -415,6 +417,8 @@
       buildDefinition("Gepland", plannedLabel ? htmlEscape(plannedLabel) : '<span class="route-export__placeholder">-</span>'),
       buildDefinition("Gewenste leverdatum", dueLabel && dueLabel !== "-" ? htmlEscape(dueLabel) : '<span class="route-export__placeholder">-</span>'),
     ];
+    const firstWorkDisplay = details.firstWork === true ? "Ja" : details.firstWork === false ? "Nee" : null;
+    planningItems.push(buildDefinition("Eerste werk?", formatValue(firstWorkDisplay)));
     const customerItems = [
       buildDefinition("Klant", formatValue(order.customer_name)),
       buildDefinition("Klantnummer", formatValue(details.customerNumber || order.customer_number)),

--- a/partials/aanvraag.html
+++ b/partials/aanvraag.html
@@ -97,6 +97,19 @@
             <label class="form-field-full">Order omschrijving
               <textarea id="oOrderDescription" rows="3" placeholder="Bijvoorbeeld: levering reachtruck aan vestiging Antwerpen"></textarea>
             </label>
+            <div class="form-toggle form-field-full">
+              <span class="toggle-label">Eerste werk?</span>
+              <div class="toggle-group">
+                <label class="toggle-option">
+                  <input type="radio" name="firstWork" id="oFirstWorkYes" value="yes" />
+                  <span>Ja</span>
+                </label>
+                <label class="toggle-option">
+                  <input type="radio" name="firstWork" id="oFirstWorkNo" value="no" checked />
+                  <span>Nee</span>
+                </label>
+              </div>
+            </div>
             <label class="checkbox form-field-full">
               <input type="checkbox" id="oCombinedFlow" />
               <span>Gecombineerde aanvraag (doorbreng en retour in één workflow)</span>
@@ -473,6 +486,10 @@
               <div class="summary-row">
                 <dt>Contact e-mail</dt>
                 <dd data-summary-field="order_contact_email">-</dd>
+              </div>
+              <div class="summary-row">
+                <dt>Eerste werk?</dt>
+                <dd data-summary-field="first_work">Nee</dd>
               </div>
               <div class="summary-row">
                 <dt>Gecombineerde aanvraag</dt>

--- a/supabase_transport.sql
+++ b/supabase_transport.sql
@@ -50,6 +50,7 @@ create table if not exists public.transport_orders (
   customer_order_number text,
   order_reference text,
   order_description text,
+  first_work boolean,
   pickup_confirmed boolean,
   pickup_location text,
   pickup_date date,
@@ -99,6 +100,7 @@ alter table public.transport_orders add column if not exists customer_contact_em
 alter table public.transport_orders add column if not exists customer_order_number text;
 alter table public.transport_orders add column if not exists order_reference text;
 alter table public.transport_orders add column if not exists order_description text;
+alter table public.transport_orders add column if not exists first_work boolean;
 alter table public.transport_orders add column if not exists pickup_confirmed boolean;
 alter table public.transport_orders add column if not exists pickup_location text;
 alter table public.transport_orders add column if not exists pickup_date date;


### PR DESCRIPTION
## Summary
- add an "Eerste werk?" toggle to the transport aanvraag wizard and show the choice in the overview
- propagate the new field through order payloads, tooltips, and route exports including the PDF generator
- extend the Supabase schema with a `first_work` column to persist the toggle value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e386025f38832ba20e558413351e25