### PR TITLE
Toon ritten vanuit Almere in routeoverzicht

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2202,6 +2202,25 @@ dialog::backdrop {
   gap: 6px;
 }
 
+.route-summary-steps {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.route-summary-step {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.route-summary-step--start,
+.route-summary-step--return {
+  font-weight: 600;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- voeg een standaardhub voor Almere toe zodat ritten altijd vanuit Almere vertrekken en eindigen
- bouw een ritstappenoverzicht per voertuig met vertrek, laden, lossen en terugkeer in de routekaart
- style de nieuwe route-overzichtslijst voor betere leesbaarheid

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68e39e0c2af0832ba939f42452e8b420